### PR TITLE
シンタックスチェック

### DIFF
--- a/includes/parse.h
+++ b/includes/parse.h
@@ -1,5 +1,6 @@
 #ifndef PARSE_H
 # define PARSE_H
+//# define DEBUG printf("debug\n")
 
 # include "minishell.h"
 # include "../libft/libft.h"
@@ -33,6 +34,8 @@ t_token		*trim_list(t_token *list);
 bool		is_space_after_quot(t_token *list);
 void		set_special_c(t_token *list);
 
+t_execdata	*check_syntax(t_execdata *data);
+void		put_syntax_error(char *str);
 
 // *test
 void		put_execdata(t_execdata *data);

--- a/srcs/check_syntax.c
+++ b/srcs/check_syntax.c
@@ -1,0 +1,44 @@
+#include "../includes/parse.h"
+
+void	put_syntax_error(char *str)
+{
+	ft_putstr_fd("minishell: syntax error near unexpected token ",
+		 STDERR_FILENO);
+	ft_putendl_fd(str, STDERR_FILENO);
+}
+
+int	check_iolist(t_iolist *list)
+{
+	t_iolist	*prev;
+
+	prev = NULL;
+	while (list)
+	{
+		if (prev && prev->c_type <= OUT_HERE_DOC
+			&& list->c_type <= OUT_HERE_DOC)
+		{
+			put_syntax_error(list->str);
+			return (-1);
+		}
+		prev = list;
+		list = list->next;
+	}
+	return (0);
+}
+
+t_execdata	*check_syntax(t_execdata *data)
+{
+	t_execdata	*head;
+
+	head = data;
+	while (data)
+	{
+		if (check_iolist(data->iolst) == -1)
+		{
+			clear_execdata(head);
+			return (NULL);
+		}
+		data = data->next;
+	}
+	return (head);
+}

--- a/srcs/execdata_utils.c
+++ b/srcs/execdata_utils.c
@@ -1,6 +1,6 @@
 #include "../includes/parse.h"
 
-t_cmdlist	*new_clst(t_cmdlist *cur, t_token *token)
+static t_cmdlist	*new_clst(t_cmdlist *cur, t_token *token)
 {
 	t_cmdlist	*new;
 
@@ -8,7 +8,19 @@ t_cmdlist	*new_clst(t_cmdlist *cur, t_token *token)
 	cur->next = new;
 	new->prev = cur;
 	new->str = ft_xstrdup(token->str);
+	new->quot = token->type;
 	return (new);
+}
+
+static bool	is_cmd(t_token *start)
+{
+	if (start->special == ELSE
+		&& (start->prev == NULL
+			|| start->prev->special == ELSE
+			|| start->prev->special == PIPE))
+		return (true);
+	else
+		return (false);
 }
 
 t_cmdlist	*get_clst(t_token *start, t_token *cur_token)
@@ -21,10 +33,7 @@ t_cmdlist	*get_clst(t_token *start, t_token *cur_token)
 		;
 	while (start != cur_token)
 	{
-		if (start->special == ELSE
-			&& (start->prev == NULL
-				|| start->prev->special == ELSE
-				|| start->prev->special == PIPE))
+		if (is_cmd(start))
 		{
 			cur = new_clst(cur, start);
 		}
@@ -35,7 +44,7 @@ t_cmdlist	*get_clst(t_token *start, t_token *cur_token)
 	return (cur);
 }
 
-t_iolist	*new_iolst(t_iolist *cur, t_token *token)
+static t_iolist	*new_iolst(t_iolist *cur, t_token *token)
 {
 	t_iolist	*new;
 
@@ -46,6 +55,7 @@ t_iolist	*new_iolst(t_iolist *cur, t_token *token)
 	cur->next = new;
 	new->prev = cur;
 	new->str = ft_xstrdup(token->str);
+	new->quot = token->type;
 	return (new);
 }
 
@@ -59,8 +69,7 @@ t_iolist	*get_iolst(t_token *start, t_token *cur_token)
 	cur = &head;
 	while (start != cur_token)
 	{
-		if ((start->special >= IN_REDIRECT && start->special <= OUT_HERE_DOC)
-			|| (start->prev && prev >= IN_REDIRECT && prev <= OUT_HERE_DOC))
+		if (!is_cmd(start))
 		{
 			cur = new_iolst(cur, start);
 		}

--- a/srcs/parse_cmd.c
+++ b/srcs/parse_cmd.c
@@ -8,8 +8,6 @@ int	parse_tokenlist(t_token *list)
 	head = list;
 	while (list)
 	{
-		if (is_space_after_quot(list))
-			list = trim_list(list);
 		if (is_consecutive_redirect(list))
 			list = join_redirect(list);
 		prev = list;
@@ -19,7 +17,7 @@ int	parse_tokenlist(t_token *list)
 	if (prev->special == PIPE)
 	{
 		clear_tokenlist(head);
-		ft_putendl_fd("Error: ", STDERR_FILENO);
+		put_syntax_error("|");
 		return (-1);
 	}
 	else
@@ -37,9 +35,8 @@ t_execdata	*parse_cmd(char *command, char **envp)
 		return (NULL);
 	if (split_operater(tokenlist) == -1 || parse_tokenlist(tokenlist) == -1)
 		return (NULL);
-	put_tokenlist(tokenlist);
 	envlist = create_envlist(envp);
 	data = create_execdata(tokenlist, envlist);
 	clear_tokenlist(tokenlist);
-	return (data);
+	return (check_syntax(data));
 }

--- a/srcs/parse_cmd_utils1.c
+++ b/srcs/parse_cmd_utils1.c
@@ -18,18 +18,18 @@ static t_token	*new_token(t_token *cur, char **cmd,
 	t_token	*tok;
 	int		len;
 
-	if (*flag_quot == D_QUOT || *flag_quot == S_QUOT)
-	{
-		ft_putendl_fd("Error: Quotes are not closed", STDERR_FILENO);
-		return (NULL);
-	}
 	tok = ft_xcalloc(1, sizeof(*tok));
 	len = *cmd - *start;
 	tok->str = ft_xsubstr(*start, 0, len);
 	tok->type = *flag_quot;
 	cur->next = tok;
 	tok->prev = cur;
-	while (ft_isspace(**cmd) && *flag_quot == DEFAULT)
+	if (*flag_quot == D_QUOT || *flag_quot == S_QUOT)
+	{
+		put_syntax_error(tok->str);
+		return (NULL);
+	}
+	while (ft_isspace(**cmd))
 		(*cmd)++;
 	*start = *cmd;
 	return (tok);


### PR DESCRIPTION
以下のシンタックスエラーはエラーメッセージ吐いてNULLを返すようにしました。
- クォーテーションが閉じられていない
- パイプで終わっている
- リダイレクトの記号が連続している