### PR TITLE
ヘッダーとファイル、関数名などの整理

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -1,29 +1,17 @@
-#ifndef RAKIYAMA_H
-# define RAKIYAMA_H
+#ifndef EXECUTE_H
+# define EXECUTE_H
 
 # include "minishell.h"
-# include <stdio.h>
-# include <stdlib.h>
-# include <unistd.h>
-# include <fcntl.h>
-# include <sys/types.h>
-# include <sys/wait.h>
-# include <sys/stat.h>
-# include <string.h>
-# include <errno.h>
-# include <stdbool.h>
-# include <readline/readline.h>
-# include <readline/history.h>
 
 //execute_start.c
 void	execute_command(t_execdata *data);
 int		execute_loop(t_execdata *data);
 void	execute_start(t_execdata *data);
 
-//setdata.c
+//execute_setdata.c
 int		setdata_cmdline_redirect(t_execdata *data);
 int		is_cmd_type(t_cmdlist *clst);
-enum e_cmd	get_here_doc(char *limiter);
+t_cmd	get_here_doc(char *limiter);
 void	setdata_heredoc_cmdtype(t_execdata *data);
 
 //command.c
@@ -37,24 +25,22 @@ void	builtin_exit(t_execdata *data);
 void	non_builtin(t_execdata *data);
 void	non_command(t_execdata *data);
 
-//utils_execute.c
+//execute_utils_wrapper.c
 int	ft_stat(char *pathname);
 int	ft_dup2(int oldfd, int newfd);
 int	ft_open(char *filepath, int flags, mode_t mode);
 
-//utils_env.c
+//env_functions.c
 char	*ft_getenv(t_envlist *elst, char *search_key);
 t_envlist	*ft_unsetenv(t_envlist *elst, char *rm_key);
 void	ft_setenv(t_envlist *elst, char *new_key, char *new_value, int append);
 
-//utils_list.c
-size_t	envlist_size(t_envlist *head);
-size_t	cmdlist_size(t_cmdlist *head);
+//execute_utils_list.c
 char	**convert_envlist_2dchar(t_envlist *elst);
 char	**convert_cmdlist_2dchar(t_cmdlist *clst);
 
-//utils_libft.c
-long	ft_atolong(char *str, bool *nonnum_check);
+//execute_utils_libft.c
+long	ft_atol(char *str, bool *nonnum_check);
 int		ft_strcmp(char *s1, char *s2);
 void	free_2d_array(char **array);
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -1,6 +1,18 @@
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
+# include <stdio.h>
+# include <stdlib.h>
+# include <unistd.h>
+# include <fcntl.h>
+# include <sys/types.h>
+# include <sys/wait.h>
+# include <sys/stat.h>
+# include <string.h>
+# include <errno.h>
+# include <stdbool.h>
+# include <readline/readline.h>
+# include <readline/history.h>
 # include "../libft/libft.h"
 
 typedef enum e_quottype
@@ -22,7 +34,7 @@ typedef enum e_special_c
 	ELSE
 }	t_special_c;
 
-enum e_cmd
+typedef enum e_cmd
 {
 	ECHO,
 	CD,
@@ -34,23 +46,14 @@ enum e_cmd
 	OTHER,
 	NON_CMD,
 	CMD_NUM
-};
+}	t_cmd;
 
-enum e_pipefd
+typedef enum e_pipefd
 {
 	READ,
 	WRITE,
 	PIPEFD_NUM
-};
-
-typedef struct s_iolist
-{
-	t_special_c		c_type;
-	char			*str;
-	char			*quot;
-	int				here_doc_fd;
-	struct s_iolist	*next;
-}	t_iolist;
+}	t_pipefd;
 
 typedef struct s_token
 {
@@ -60,6 +63,15 @@ typedef struct s_token
 	struct s_token	*next;
 	struct s_token	*prev;
 }	t_token;
+
+typedef struct s_iolist
+{
+	t_special_c		c_type;
+	char			*str;
+	char			*quot;
+	int				here_doc_fd;
+	struct s_iolist	*next;
+}	t_iolist;
 
 typedef struct s_cmdlist
 {
@@ -80,9 +92,12 @@ typedef struct s_execdata
 	char				**cmdline;
 	int					in_fd;
 	int					out_fd;
+	int					ori_stdin;
+	int					ori_stdout;
+	int					ori_stderr;
 	unsigned char		*status;
 	int					pipefd[PIPEFD_NUM];
-	enum e_cmd			cmd_type;
+	t_cmd				cmd_type;
 	t_cmdlist			*clst;
 	t_iolist			*iolst;
 	t_envlist			*elst;
@@ -90,7 +105,7 @@ typedef struct s_execdata
 }	t_execdata;
 
 # include "parse.h"
-# include "rakiyama.h"
+# include "execute.h"
 t_execdata	*parse_cmd(char *command, t_envlist *envlist, unsigned char *status);
 t_envlist	*create_envlist(char **envp);
 

--- a/rakiyama/for_running_and_utils.c
+++ b/rakiyama/for_running_and_utils.c
@@ -1,4 +1,4 @@
-#include "rakiyama.h"
+#include "execute.h"
 
 void	put_2d_array(char **a)
 {
@@ -75,8 +75,6 @@ t_execdata	*add_execdata(t_execdata *data, unsigned char *s, t_cmdlist *clst, t_
 
 	tmp = (t_execdata *)malloc(sizeof(t_execdata));
 	tmp->cmdline = NULL;
-	tmp->in_fd = STDIN_FILENO;
-	tmp->out_fd = STDOUT_FILENO;
 	tmp->status = s;
 	tmp->clst = clst;
 	tmp->iolst = iolst;
@@ -181,8 +179,8 @@ int	main(int ac, char **av, char **envp)
 	status = (unsigned char *)malloc(sizeof(unsigned char));
 	*status = 0;
 	clst = NULL;
-	clst = add_cmdlist(clst, "echo");
-	clst = add_cmdlist(clst, "akiyama");
+	clst = add_cmdlist(clst, "cat");
+	clst = add_cmdlist(clst, "-e");
 	iolst = NULL;
 	iolst = add_iolist(iolst, IN_HERE_DOC, "<<", -1);
 	iolst = add_iolist(iolst, ELSE, "limit", -1);
@@ -211,8 +209,6 @@ int	main(int ac, char **av, char **envp)
 	clst = NULL;
 	clst = add_cmdlist(clst, "env");
 	iolst = NULL;
-	iolst = add_iolist(iolst, OUT_REDIRECT, ">", -1);
-	iolst = add_iolist(iolst, ELSE, "envoutfile", -1);
 	data = add_execdata(data, status, clst, iolst, elst);
 	execute_start(data);
 	exit_status = *(data->status);
@@ -222,6 +218,27 @@ int	main(int ac, char **av, char **envp)
 	clst = NULL;
 	clst = add_cmdlist(clst, "export");
 	clst = add_cmdlist(clst, "EEE+=uuuuuuuui");	
+	iolst = NULL;
+	data = add_execdata(data, status, clst, iolst, elst);
+	execute_start(data);
+	exit_status = *(data->status);
+	free_data(data, 0, 0);
+
+	data = NULL;
+	clst = NULL;
+	clst = add_cmdlist(clst, "echo");
+	clst = add_cmdlist(clst, "---------------");
+	clst = add_cmdlist(clst, "---env    export---");
+	clst = add_cmdlist(clst, "---------------");
+	iolst = NULL;
+	data = add_execdata(data, status, clst, iolst, elst);
+	execute_start(data);
+	exit_status = *(data->status);
+	free_data(data, 0, 0);
+
+	data = NULL;
+	clst = NULL;
+	clst = add_cmdlist(clst, "export");
 	iolst = NULL;
 	data = add_execdata(data, status, clst, iolst, elst);
 	execute_start(data);

--- a/rakiyama/run.sh
+++ b/rakiyama/run.sh
@@ -1,3 +1,5 @@
 make -C ../libft
 gcc -lreadline -lhistory -L/usr/local/opt/readline/lib -I/usr/local/opt/readline/include -I ../includes/ ../srcs/*.c for_running_and_utils.c ../libft/libft.a
-#./a.out
+./a.out
+rm a.out
+make fclean -C ../libft

--- a/srcs/command.c
+++ b/srcs/command.c
@@ -1,4 +1,4 @@
-# include "rakiyama.h"
+# include "execute.h"
 
 /*
 ** all command functions
@@ -12,14 +12,13 @@ void	builtin_echo(t_execdata *data)
 
 	option = 0;
 	arg_i = 1;
-	if (data->cmdline[arg_i] && ft_strcmp(data->cmdline[arg_i], "-n") == 0)
-	{
+	if (data->cmdline[arg_i] && ft_strcmp(data->cmdline[arg_i], "-n") == 0 && arg_i++)
 		option++;
-		arg_i++;
-	}
 	while (data->cmdline[arg_i])
 	{
 		printf("%s", data->cmdline[arg_i]);
+		if (data->cmdline[arg_i + 1] != NULL)
+			printf(" ");
 		arg_i++;
 	}
 	if (option == 0)
@@ -200,7 +199,7 @@ void	builtin_exit(t_execdata *data)
 		*(data->status) = 1;
 		return ;
 	}
-	*(data->status) = (unsigned char)ft_atolong(data->cmdline[1], &nonnum_check);
+	*(data->status) = (unsigned char)ft_atol(data->cmdline[1], &nonnum_check);
 	ft_putendl_fd("exit", STDERR_FILENO);
 	if (nonnum_check)
 	{

--- a/srcs/env_functions.c
+++ b/srcs/env_functions.c
@@ -1,4 +1,4 @@
-# include "rakiyama.h"
+# include "execute.h"
 
 char	*ft_getenv(t_envlist *elst, char *search_key)
 {

--- a/srcs/execute_setdata.c
+++ b/srcs/execute_setdata.c
@@ -1,4 +1,4 @@
-#include "rakiyama.h"
+#include "execute.h"
 
 
 int	setdata_cmdline_redirect(t_execdata *data)
@@ -51,7 +51,7 @@ int	is_cmd_type(t_cmdlist *clst)
 		return(OTHER);
 }
 
-enum e_cmd	get_here_doc(char *limiter)
+t_cmd	get_here_doc(char *limiter)
 {
 	char*	line;
 	int		pipefd[PIPEFD_NUM];

--- a/srcs/execute_utils_libft.c
+++ b/srcs/execute_utils_libft.c
@@ -1,4 +1,4 @@
-# include "rakiyama.h"
+# include "execute.h"
 
 static bool check_nonnum_overflow(unsigned long num, char *str, int sign, size_t i)
 {
@@ -9,7 +9,7 @@ static bool check_nonnum_overflow(unsigned long num, char *str, int sign, size_t
 	return (false);
 }
 
-long	ft_atolong(char *str, bool *nonnum_check)
+long	ft_atol(char *str, bool *nonnum_check)
 {
 	size_t			i;
 	unsigned long	num;

--- a/srcs/execute_utils_list.c
+++ b/srcs/execute_utils_list.c
@@ -1,6 +1,6 @@
-# include "rakiyama.h"
+# include "execute.h"
 
-size_t	envlist_size(t_envlist *head)
+static size_t	envlist_size(t_envlist *head)
 {
 	t_envlist	*move;
 	size_t		cnt;
@@ -15,7 +15,7 @@ size_t	envlist_size(t_envlist *head)
 	return (cnt);
 }
 
-size_t	cmdlist_size(t_cmdlist *head)
+static size_t	cmdlist_size(t_cmdlist *head)
 {
 	t_cmdlist	*move;
 	size_t		cnt;

--- a/srcs/execute_utils_wrapper.c
+++ b/srcs/execute_utils_wrapper.c
@@ -1,4 +1,4 @@
-# include "rakiyama.h"
+# include "execute.h"
 
 /*check if the file exists*/
 int	ft_stat(char *pathname)

--- a/srcs/wrapper2.c
+++ b/srcs/wrapper2.c
@@ -1,4 +1,4 @@
-#include "rakiyama.h"
+#include "execute.h"
 
 char	*ft_xstrjoin(char *str1, char *str2)
 {


### PR DESCRIPTION
#18 
# minishell.hの変更
- enum e_~ → t_~
- 標準ライブラリのincludeを追加
- execdataのメンバーに下記追加
    - ori_stdin
    - ori_stdout
    - ori_stderr
    in_fd,out_fdは消す予定なのでそれは後で話しましょう。

# srcsとrakiyama.hの変更
- rakiyama.h→execute.h
- ファイル名変更(ft_getenvはenv_functions.cに入ります）
- 関数名変更
- コメントの追加
- echoで出力ごとに空白を入れる
- srcs/execute_start.c内に下記追加
    - enumの追加
    stdfd_handler()で使う、ひとまずこのファイル内で定義
    - stdfd_handler()の追加
    標準入出力の保存・回復で使います