### PR TITLE
fix: is_dilimiter

### DIFF
--- a/srcs/check_syntax.c
+++ b/srcs/check_syntax.c
@@ -11,39 +11,3 @@ void	put_syntax_error(char *str)
 		 STDERR_FILENO);
 	ft_putendl_fd(str, STDERR_FILENO);
 }
-
-int	check_iolist(t_iolist *list)
-{
-	t_iolist	*prev;
-
-	prev = NULL;
-	while (list)
-	{
-		if (prev && prev->c_type == ELSE
-			&& list->c_type == ELSE)
-		{
-			ft_putendl_fd("minishell: ambiguous redirect", STDERR_FILENO);
-			return (-1);
-		}
-		prev = list;
-		list = list->next;
-	}
-	return (0);
-}
-
-t_execdata	*check_syntax(t_execdata *data)
-{
-	t_execdata	*head;
-
-	head = data;
-	while (data)
-	{
-		if (check_iolist(data->iolst) == -1)
-		{
-			*(data->status) = 1;
-			return (head);
-		}
-		data = data->next;
-	}
-	return (head);
-}

--- a/srcs/expansion_utils2.c
+++ b/srcs/expansion_utils2.c
@@ -2,7 +2,7 @@
 
 bool	is_delimiter(char c)
 {
-	if (c == ' ' || c == '$' || c == '\"' || c == '\'' || c == '\0')
+	if (!(ft_isalnum(c) || c == '_'))
 		return (true);
 	else
 		return (false);

--- a/srcs/parse_cmd.c
+++ b/srcs/parse_cmd.c
@@ -38,5 +38,5 @@ t_execdata	*parse_cmd(char *command, t_envlist *envlist, unsigned char *status)
 	data = create_execdata(tokenlist, envlist, status);
 	clear_tokenlist(tokenlist);
 	expansion(data);
-	return (check_syntax(data));
+	return (data);
 }

--- a/test/result.txt
+++ b/test/result.txt
@@ -312,6 +312,48 @@ command: [echo "'"$USER"'"]
 	  quot: D00000000D
 
 
+command: [echo $USER?]
+[41mexecdata[0][49m
+	*status: 0
+	in_fd: 0
+	out_fd: 1
+
+	[32mcmdlist[0][39m
+	  str: "echo"
+	  quot: 0000
+	[32mcmdlist[1][39m
+	  str: "sudourio?"
+	  quot: 000000000
+
+
+command: [echo $USER_]
+[41mexecdata[0][49m
+	*status: 0
+	in_fd: 0
+	out_fd: 1
+
+	[32mcmdlist[0][39m
+	  str: "echo"
+	  quot: 0000
+	[32mcmdlist[1][39m
+	  str: ""
+	  quot: 
+
+
+command: [echo $USER!]
+[41mexecdata[0][49m
+	*status: 0
+	in_fd: 0
+	out_fd: 1
+
+	[32mcmdlist[0][39m
+	  str: "echo"
+	  quot: 0000
+	[32mcmdlist[1][39m
+	  str: "sudourio!"
+	  quot: 000000000
+
+
 command: [echo "aa$VAR"]
 [41mexecdata[0][49m
 	*status: 0
@@ -504,10 +546,9 @@ command: [echo >"aa$VAR"]
 	  here_doc_fd: -1
 
 
-minishell: ambiguous redirect
 command: [echo >aa$VAR]
 [41mexecdata[0][49m
-	*status: 1
+	*status: 0
 	in_fd: 0
 	out_fd: 1
 


### PR DESCRIPTION
#20 
`is_delimiter`を修正して、数字、アルファベット、アンダーバー以外の文字を区切り文字と認識するようにしました。
test/result.txtの315行目〜354行目でテスト結果が出力してあります。