### PR TITLE
minishellを動かすループ関数の作成

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -57,4 +57,7 @@ void		xwaitpid(pid_t pid, int *wstatus, int options);
 void		xpipe(int *pipefd);
 pid_t		xfork(void);
 
+//minishell_loop.c
+void		minishell_loop(char **envp);
+
 #endif

--- a/rakiyama/for_running_and_utils.c
+++ b/rakiyama/for_running_and_utils.c
@@ -14,6 +14,40 @@ void	put_2d_array(char **a)
 	}
 }
 
+void	put_data(t_execdata *data)
+{
+	t_cmdlist	*ctmp;
+	t_iolist	*iotmp;
+	t_envlist	*etmp;
+
+	while(data)
+	{
+		printf("--------------------------------------------\n");
+		printf("status:%d\n", *(data->status));
+		ctmp = data->clst;
+		while (ctmp)
+		{
+			printf("cmdlist:%s\n", ctmp->str);
+			ctmp = ctmp->next;
+		}
+		iotmp = data->iolst;
+		while (iotmp)
+		{
+			printf("iolist:%s\n", iotmp->str);
+			iotmp = iotmp->next;
+		}
+		etmp = data->elst;
+		while (etmp)
+		{
+			printf("env key:%s\n", etmp->key);
+			printf("env value:%s\n", etmp->value);
+			etmp = etmp->next;
+		}
+		data = data->next;
+	}
+}
+
+
 t_cmdlist	*add_cmdlist(t_cmdlist *clst, char *s)
 {
 	t_cmdlist	*tmp;
@@ -89,38 +123,6 @@ t_execdata	*add_execdata(t_execdata *data, unsigned char *s, t_cmdlist *clst, t_
 	return (data);
 }
 
-void	put_data(t_execdata *data)
-{
-	t_cmdlist	*ctmp;
-	t_iolist	*iotmp;
-	t_envlist	*etmp;
-
-	while(data)
-	{
-		printf("--------------------------------------------\n");
-		printf("status:%d\n", *(data->status));
-		ctmp = data->clst;
-		while (ctmp)
-		{
-			printf("cmdlist:%s\n", ctmp->str);
-			ctmp = ctmp->next;
-		}
-		iotmp = data->iolst;
-		while (iotmp)
-		{
-			printf("iolist:%s\n", iotmp->str);
-			iotmp = iotmp->next;
-		}
-		etmp = data->elst;
-		while (etmp)
-		{
-			printf("env key:%s\n", etmp->key);
-			printf("env value:%s\n", etmp->value);
-			etmp = etmp->next;
-		}
-		data = data->next;
-	}
-}
 
 void	free_data(t_execdata *data, int status_free, int elst_free)
 {
@@ -159,105 +161,106 @@ void	free_data(t_execdata *data, int status_free, int elst_free)
 
 int	main(int ac, char **av, char **envp)
 {
-	t_cmdlist	*clst;
-	t_iolist	*iolst;
-	t_envlist	*elst;
-	t_execdata	*data;
-	unsigned char	*status;
-	t_envlist	*etmp;
-	int			exit_status;
+	// t_cmdlist	*clst;
+	// t_iolist	*iolst;
+	// t_envlist	*elst;
+	// t_execdata	*data;
+	// unsigned char	*status;
+	// t_envlist	*etmp;
+	// int			exit_status;
 
 
-	data = NULL;
-	elst = NULL;
-	elst = add_envlist(elst, ft_strdup("HOME"), ft_strdup("/Users/ryojiroakiyama"));
-	elst = add_envlist(elst, ft_strdup("PATH"), ft_strdup("/Users/ryojiroakiyama/.pyenv/shims:/Users/ryojiroakiyama/.pyenv/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands"));
-	elst = add_envlist(elst, ft_strdup("EEE"), ft_strdup("aaaaaaai"));
-	elst = add_envlist(elst, ft_strdup("PWD"), ft_strdup("/Users/ryojiroakiyama/Desktop/icloud/42_cursus/minishell/minishell/rakiyama"));
-	elst = add_envlist(elst, ft_strdup("RYOJIRO"), ft_strdup("ryojiro"));
-	elst = add_envlist(elst, ft_strdup("AKIYAMA"), ft_strdup("akiyama"));
-	status = (unsigned char *)malloc(sizeof(unsigned char));
-	*status = 0;
-	clst = NULL;
-	clst = add_cmdlist(clst, "cat");
-	clst = add_cmdlist(clst, "-e");
-	iolst = NULL;
-	iolst = add_iolist(iolst, IN_HERE_DOC, "<<", -1);
-	iolst = add_iolist(iolst, ELSE, "limit", -1);
-	iolst = add_iolist(iolst, OUT_REDIRECT, ">", -1);
-	iolst = add_iolist(iolst, ELSE, "outfile", -1);
-	data = add_execdata(data, status, clst, iolst, elst);
-	execute_start(data);
-	exit_status = *(data->status);
-	free_data(data, 0, 0);
+	// data = NULL;
+	// elst = NULL;
+	// elst = add_envlist(elst, ft_strdup("HOME"), ft_strdup("/Users/ryojiroakiyama"));
+	// elst = add_envlist(elst, ft_strdup("PATH"), ft_strdup("/Users/ryojiroakiyama/.pyenv/shims:/Users/ryojiroakiyama/.pyenv/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands"));
+	// elst = add_envlist(elst, ft_strdup("EEE"), ft_strdup("aaaaaaai"));
+	// elst = add_envlist(elst, ft_strdup("PWD"), ft_strdup("/Users/ryojiroakiyama/Desktop/icloud/42_cursus/minishell/minishell/rakiyama"));
+	// elst = add_envlist(elst, ft_strdup("RYOJIRO"), ft_strdup("ryojiro"));
+	// elst = add_envlist(elst, ft_strdup("AKIYAMA"), ft_strdup("akiyama"));
+	// status = (unsigned char *)malloc(sizeof(unsigned char));
+	// *status = 0;
+	// clst = NULL;
+	// clst = add_cmdlist(clst, "cat");
+	// clst = add_cmdlist(clst, "-e");
+	// iolst = NULL;
+	// iolst = add_iolist(iolst, IN_HERE_DOC, "<<", -1);
+	// iolst = add_iolist(iolst, ELSE, "limit", -1);
+	// iolst = add_iolist(iolst, OUT_REDIRECT, ">", -1);
+	// iolst = add_iolist(iolst, ELSE, "outfile", -1);
+	// data = add_execdata(data, status, clst, iolst, elst);
+	// execute_start(data);
+	// exit_status = *(data->status);
+	// free_data(data, 0, 0);
 
-	data = NULL;
-	clst = NULL;
-	clst = add_cmdlist(clst, "cat");
-	clst = add_cmdlist(clst, "-n");	
-	iolst = NULL;
-	iolst = add_iolist(iolst, IN_REDIRECT, "<", -1);
-	iolst = add_iolist(iolst, ELSE, "outfile", -1);
-	iolst = add_iolist(iolst, OUT_HERE_DOC, ">>", -1);
-	iolst = add_iolist(iolst, ELSE, "outfile", -1);
-	data = add_execdata(data, status, clst, iolst, elst);
-	execute_start(data);
-	exit_status = *(data->status);
-	free_data(data, 0, 0);
+	// data = NULL;
+	// clst = NULL;
+	// clst = add_cmdlist(clst, "cat");
+	// clst = add_cmdlist(clst, "-n");	
+	// iolst = NULL;
+	// iolst = add_iolist(iolst, IN_REDIRECT, "<", -1);
+	// iolst = add_iolist(iolst, ELSE, "outfile", -1);
+	// iolst = add_iolist(iolst, OUT_HERE_DOC, ">>", -1);
+	// iolst = add_iolist(iolst, ELSE, "outfile", -1);
+	// data = add_execdata(data, status, clst, iolst, elst);
+	// execute_start(data);
+	// exit_status = *(data->status);
+	// free_data(data, 0, 0);
 
-	data = NULL;
-	clst = NULL;
-	clst = add_cmdlist(clst, "env");
-	iolst = NULL;
-	data = add_execdata(data, status, clst, iolst, elst);
-	execute_start(data);
-	exit_status = *(data->status);
-	free_data(data, 0, 0);
+	// data = NULL;
+	// clst = NULL;
+	// clst = add_cmdlist(clst, "env");
+	// iolst = NULL;
+	// data = add_execdata(data, status, clst, iolst, elst);
+	// execute_start(data);
+	// exit_status = *(data->status);
+	// free_data(data, 0, 0);
 
-	data = NULL;
-	clst = NULL;
-	clst = add_cmdlist(clst, "export");
-	clst = add_cmdlist(clst, "EEE+=uuuuuuuui");	
-	iolst = NULL;
-	data = add_execdata(data, status, clst, iolst, elst);
-	execute_start(data);
-	exit_status = *(data->status);
-	free_data(data, 0, 0);
+	// data = NULL;
+	// clst = NULL;
+	// clst = add_cmdlist(clst, "export");
+	// clst = add_cmdlist(clst, "EEE+=uuuuuuuui");	
+	// iolst = NULL;
+	// data = add_execdata(data, status, clst, iolst, elst);
+	// execute_start(data);
+	// exit_status = *(data->status);
+	// free_data(data, 0, 0);
 
-	data = NULL;
-	clst = NULL;
-	clst = add_cmdlist(clst, "echo");
-	clst = add_cmdlist(clst, "---------------");
-	clst = add_cmdlist(clst, "---env    export---");
-	clst = add_cmdlist(clst, "---------------");
-	iolst = NULL;
-	data = add_execdata(data, status, clst, iolst, elst);
-	execute_start(data);
-	exit_status = *(data->status);
-	free_data(data, 0, 0);
+	// data = NULL;
+	// clst = NULL;
+	// clst = add_cmdlist(clst, "echo");
+	// clst = add_cmdlist(clst, "---------------");
+	// clst = add_cmdlist(clst, "---env    export---");
+	// clst = add_cmdlist(clst, "---------------");
+	// iolst = NULL;
+	// data = add_execdata(data, status, clst, iolst, elst);
+	// execute_start(data);
+	// exit_status = *(data->status);
+	// free_data(data, 0, 0);
 
-	data = NULL;
-	clst = NULL;
-	clst = add_cmdlist(clst, "export");
-	iolst = NULL;
-	data = add_execdata(data, status, clst, iolst, elst);
-	execute_start(data);
-	exit_status = *(data->status);
-	free_data(data, 0, 0);
+	// data = NULL;
+	// clst = NULL;
+	// clst = add_cmdlist(clst, "export");
+	// iolst = NULL;
+	// data = add_execdata(data, status, clst, iolst, elst);
+	// execute_start(data);
+	// exit_status = *(data->status);
+	// free_data(data, 0, 0);
 
-	data = NULL;
-	clst = NULL;
-	clst = add_cmdlist(clst, "exit");
-	clst = add_cmdlist(clst, "5829039");
-	iolst = NULL;
-	data = add_execdata(data, status, clst, iolst, elst);
-	execute_start(data);
-	exit_status = *(data->status);
-	free_data(data, 1, 1);
+	// data = NULL;
+	// clst = NULL;
+	// clst = add_cmdlist(clst, "exit");
+	// clst = add_cmdlist(clst, "5829039");
+	// iolst = NULL;
+	// data = add_execdata(data, status, clst, iolst, elst);
+	// execute_start(data);
+	// exit_status = *(data->status);
+	// free_data(data, 1, 1);
 
-//	put_data(data);
+	minishell_loop(envp);
 
 	if (system("leaks a.out > /dev/null"))
 		system("leaks a.out");
-	return (exit_status);
+//	return (exit_status);
+	return (0);
 }

--- a/rakiyama/run.sh
+++ b/rakiyama/run.sh
@@ -1,5 +1,5 @@
 make -C ../libft
-gcc -lreadline -lhistory -L/usr/local/opt/readline/lib -I/usr/local/opt/readline/include -I ../includes/ ../srcs/*.c for_running_and_utils.c ../libft/libft.a
+gcc -fsanitize=address -g -lreadline -lhistory -L/usr/local/opt/readline/lib -I/usr/local/opt/readline/include -I ../includes/ ../srcs/*.c for_running_and_utils.c ../libft/libft.a
 ./a.out
-rm a.out
-make fclean -C ../libft
+#rm a.out
+#make fclean -C ../libft

--- a/srcs/execution_start.c
+++ b/srcs/execution_start.c
@@ -32,25 +32,26 @@ void	execute_command(t_execdata *data)
 int	execute_loop(t_execdata *data)
 {
 	int	pid;
+	int	pipefd[PIPEFD_NUM];
+	int	prev_pipe_read;
 
+	prev_pipe_read = STDIN_FILENO;
 	while (data)
 	{
-		xpipe(data->pipefd);
+		xpipe(pipefd);
 		pid = xfork();
 		if (pid == 0)
 		{
-			xclose(data->pipefd[READ]);
+			ft_dup2(prev_pipe_read, STDIN_FILENO);
+			xclose(pipefd[READ]);
 			if (data->next != NULL)
-				ft_dup2(data->pipefd[WRITE], STDOUT_FILENO);
+				ft_dup2(pipefd[WRITE], STDOUT_FILENO);
 			if (setdata_cmdline_redirect(data) == 0)
 				execute_command(data);
 			exit(*(data->status));
 		}
-		else
-		{
-			xclose(data->pipefd[WRITE]);
-			ft_dup2(data->pipefd[READ], STDIN_FILENO);
-		}
+		xclose(pipefd[WRITE]);
+		prev_pipe_read = pipefd[READ];
 		data = data->next;
 	}
 	return (pid);

--- a/srcs/minishell_loop.c
+++ b/srcs/minishell_loop.c
@@ -1,0 +1,23 @@
+#include "minishell.h"
+
+void	minishell_loop(char **envp)
+{
+	unsigned char	*status;
+	t_envlist		*elst;
+	t_execdata		*data;
+	char			*line;
+
+	status = (unsigned char *)malloc(sizeof(unsigned char));
+	*status = 0;
+	elst = create_envlist(envp);
+	while (1)
+	{
+		line = readline("minishell$ ");
+		if (!line)
+			exit(1);
+		data = parse_cmd(line, elst, status);
+		execute_start(data);
+		clear_execdata(data);
+		free(line);
+	}
+}

--- a/srcs/minishell_loop.c
+++ b/srcs/minishell_loop.c
@@ -15,9 +15,13 @@ void	minishell_loop(char **envp)
 		line = readline("minishell$ ");
 		if (!line)
 			exit(1);
-		data = parse_cmd(line, elst, status);
-		execute_start(data);
-		clear_execdata(data);
+		if (line[0] != '\0')
+		{
+			data = parse_cmd(line, elst, status);
+			execute_start(data);
+			clear_execdata(data);
+			add_history(line);
+		}
 		free(line);
 	}
 }


### PR DESCRIPTION
# 追加
#31 
- srcs/minishell_loop.cを作成、中のminishell_loop()にenvpを渡すと実行できます。
# 変更
- rakiyamaディレクトリ内の変更は僕がテストするために動かしているので無視してください。
- srcs/execute_start.c内のexcute_loop()
    - prev_pipe_read変数の追加
    パイプで入出力を繋ぐ際に、標準入出力fdに変更を加えるのは子プロセスのみにして親で標準入出力を見失うなどの面倒な現象を防ぐようにしました。
    - data->pipefdを無くし、関数何で宣言したpipefdを使うよう変更
    上の変更を行っている内にpipefdを構造体で持っておく必要がなくなったので無くしました。
# お知らせ
- dataリストのメンバー変数pipefdは無くす方向性で動いてます。(ヘッダーなどはいじってません)
- minishell_loopを実行するとminishellが始まるのですが、command not foundなどエラーを吐かせた後、一回分次のコマンド実行が無視されるという不具合があります。
- あと若干実行速度が遅いかもです。