### PR TITLE
catバグる問題修正

### DIFF
--- a/srcs/tokenize1.c
+++ b/srcs/tokenize1.c
@@ -73,7 +73,7 @@ t_token	*tokenize_cmd_by_space(char *cmd, unsigned char *status, bool *err)
 	while (*cmd)
 	{
 		if (ft_isspace(*cmd) && !(flag_quot == D_QUOT || flag_quot == S_QUOT))
-			cur = new_token(cur, &cmd, &start, &flag_quot);
+			cur = new_token(cur, &cmd, &start, &flag_quot), cmd--;
 		flag_quot = get_flag_quot(cmd, flag_quot), cmd++;
 	}
 	if (cur != NULL && cmd != start)


### PR DESCRIPTION
#35 
command文字列の後ろにスペースがあった場合、74行目のwhileで`cmd`ポインターを文字列の外まで進めてしまっていました。