### PR TITLE
fix : signal

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -4,7 +4,7 @@
 void	handler(int signo)
 {
 	(void)signo;
-	write(1, "\n", 1);
+	ft_putchar_fd('\n', STDOUT_FILENO);
 	rl_replace_line("", 0);
 	rl_on_new_line();
 	rl_redisplay();
@@ -13,6 +13,7 @@ void	handler(int signo)
 int	main(int argc, char **argv, char **envp)
 {
 	signal(SIGINT, handler);
+	signal(SIGQUIT, SIG_IGN);
 	minishell_loop(envp);
 	(void)argc;
 	(void)argv;

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -12,8 +12,12 @@ void	handler(int signo)
 
 int	main(int argc, char **argv, char **envp)
 {
-	signal(SIGINT, handler);
-	signal(SIGQUIT, SIG_IGN);
+	if (signal(SIGINT, handler) == SIG_ERR
+		|| signal(SIGQUIT, SIG_IGN) == SIG_ERR)
+	{
+		perror("signal");
+		exit(EXIT_FAILURE);
+	}
 	minishell_loop(envp);
 	(void)argc;
 	(void)argv;


### PR DESCRIPTION
#36
Ctrl  + \ を押されたときの対応しました。
Ctrl + \ で送られるシグナルは`SIG_QUIT`でこれが来た場合はハンドラーに`SIG_IGN`をセットすることで無視しています。
こんな簡単なことでいいのかって感じがするんですけど、とりあえずシグナルについてはこのくらいしかやることが見つかりません。