### PR TITLE
fix: expansion

### DIFF
--- a/srcs/expansion_cmdlist.c
+++ b/srcs/expansion_cmdlist.c
@@ -99,7 +99,8 @@ void	serch_env_cmdlist(t_cmdlist *clist, t_envlist *envlist)
 	while (clist)
 	{
 		doll_ptr = ft_strchr(clist->str, '$');
-		while (doll_ptr != NULL && clist->quot[doll_ptr - clist->str] != 'S')
+		while (doll_ptr != NULL && clist->quot[doll_ptr - clist->str] != 'S'
+			&& !is_delimiter(*(doll_ptr + 1)))
 		{
 			expansion_key_cmdlist(clist, envlist, doll_ptr);
 			xfree(clist->quot);

--- a/srcs/parse_cmd.c
+++ b/srcs/parse_cmd.c
@@ -8,7 +8,6 @@ static t_execdata	*expand_variable(t_execdata *data)
 	while (data)
 	{
 		serch_env_cmdlist(data->clst, data->elst);
-		serch_env_iolist(data->iolst, data->elst);
 		data = data->next;
 	}
 	return (data);

--- a/test/compile.sh
+++ b/test/compile.sh
@@ -25,7 +25,6 @@ test_parse2.c \
 ../srcs/expansion_utils2.c \
 ../srcs/parse_cmd.c \
 ../srcs/parse_tokenlist.c \
-../srcs/signal_handler.c \
 ../srcs/tokenize1.c \
 ../srcs/tokenize2.c \
 ../srcs/tokenize_utils.c \

--- a/test/debug_parse.sh
+++ b/test/debug_parse.sh
@@ -27,7 +27,6 @@ test_parse2.c \
 ../srcs/expansion_utils2.c \
 ../srcs/parse_cmd.c \
 ../srcs/parse_tokenlist.c \
-../srcs/signal_handler.c \
 ../srcs/tokenize1.c \
 ../srcs/tokenize2.c \
 ../srcs/tokenize_utils.c \
@@ -54,6 +53,13 @@ test_parse2.c \
 ./parse 'echo "aaa > bbb"' >> result.txt
 
 ./parse 'echo "aaa << bbb"' >> result.txt
+
+./parse 'echo $' >> result.txt
+
+./parse 'echo$' >> result.txt
+
+./parse 'echo $ | cat' >> result.txt
+
 
 # expand $?
 ./parse 'echo $?' >> result.txt
@@ -139,4 +145,4 @@ diff -s result.txt answer.txt \
 | sed "s/Files result.txt and answer.txt are identical/<TEST OK>/g" \
 | GREP_COLOR='23;32' grep -E --color "$|<TEST OK>"
 
-rm parse
+# rm parse

--- a/test/result.txt
+++ b/test/result.txt
@@ -141,6 +141,43 @@ execdata[0]
 	  quot: DDDDDDDDDD
 
 
+command: [echo $]
+execdata[0]
+	*status: 0
+	cmdlist[0]
+	  str: "echo"
+	  quot: 0000
+	cmdlist[1]
+	  str: "$"
+	  quot: 0
+
+
+command: [echo$]
+execdata[0]
+	*status: 0
+	cmdlist[0]
+	  str: "echo$"
+	  quot: 00000
+
+
+command: [echo $ | cat]
+execdata[0]
+	*status: 0
+	cmdlist[0]
+	  str: "echo"
+	  quot: 0000
+	cmdlist[1]
+	  str: "$"
+	  quot: 0
+
+
+execdata[1]
+	*status: 0
+	cmdlist[0]
+	  str: "cat"
+	  quot: 000
+
+
 command: [echo $?]
 execdata[0]
 	*status: 0
@@ -354,8 +391,8 @@ execdata[0]
 	  here_doc_fd: -1
 
 	iolist[1]
-	  str: "sudourio"
-	  quot: 00000000
+	  str: "$USER"
+	  quot: 00000
 	  c_type: ELSE
 	  here_doc_fd: -1
 
@@ -374,8 +411,8 @@ execdata[0]
 	  here_doc_fd: -1
 
 	iolist[1]
-	  str: "sudourio"
-	  quot: DDDDDDDD
+	  str: ""$USER""
+	  quot: DDDDDD2
 	  c_type: ELSE
 	  here_doc_fd: -1
 
@@ -394,8 +431,8 @@ execdata[0]
 	  here_doc_fd: -1
 
 	iolist[1]
-	  str: ""$USER""
-	  quot: SSSSSSS
+	  str: "'"$USER"'"
+	  quot: SSSSSSSS1
 	  c_type: ELSE
 	  here_doc_fd: -1
 
@@ -414,8 +451,8 @@ execdata[0]
 	  here_doc_fd: -1
 
 	iolist[1]
-	  str: "sudourio"
-	  quot: 00000000
+	  str: "''$USER''"
+	  quot: S100000S1
 	  c_type: ELSE
 	  here_doc_fd: -1
 
@@ -434,8 +471,8 @@ execdata[0]
 	  here_doc_fd: -1
 
 	iolist[1]
-	  str: "sudourio"
-	  quot: 00000000
+	  str: """$USER"""
+	  quot: D200000D2
 	  c_type: ELSE
 	  here_doc_fd: -1
 
@@ -454,8 +491,8 @@ execdata[0]
 	  here_doc_fd: -1
 
 	iolist[1]
-	  str: "'sudourio'"
-	  quot: D00000000D
+	  str: ""'"$USER"'""
+	  quot: DD200000DD2
 	  c_type: ELSE
 	  here_doc_fd: -1
 
@@ -474,8 +511,8 @@ execdata[0]
 	  here_doc_fd: -1
 
 	iolist[1]
-	  str: "aa   ramen"
-	  quot: DDDDDDDDDD
+	  str: ""aa$VAR""
+	  quot: DDDDDDD2
 	  c_type: ELSE
 	  here_doc_fd: -1
 
@@ -494,16 +531,10 @@ execdata[0]
 	  here_doc_fd: -1
 
 	iolist[1]
-	  str: "aa"
-	  quot: 00
+	  str: "aa$VAR"
+	  quot: 000000
 	  c_type: ELSE
 	  here_doc_fd: -1
-
-	iolist[2]
-	  str: "ramen"
-	  quot: 00000
-	  c_type: ELSE
-	  here_doc_fd: 0
 
 
 minishell: syntax error near unexpected token |


### PR DESCRIPTION
#50 
#48 

# iolistでの変数展開しない。
parse_cmd.cの`expansion`関数でserch_enviolistを呼び出さずに
iolistでは
- 変数展開
- クォーテーションの除去
- それに伴うリストの追加

をしていません。

# $単体のときに変数展開をしない
expansion_cmdlist.cを修正して$単体のときに変数展開をしないようにしました。

# レビュー項目
「$単体」の判定の仕方ですが、$の次の文字が環境変数の区切り文字(アルファベット、数字、アンダーバー以外)だったときに「$単体」としています。 これに関して、issue #50  の方にbashで$の次に特殊文字が来た場合の挙動を載せているのですが、`$!`や`$#`などは意味は調べてないですが特有の挙動があるようです。今回、記載のない特殊文字は解釈しないので例えば
```
$ echo $!
```
はbashだと何も表示されないが、minishellは`$!`を表示するようになります。
これは問題ないという認識で大丈夫ですか？

result.txtも合わせて確認お願いします。(diffのほとんどがiolistでの環境変数で見づらいですが)