### PR TITLE
前後にスペース含む環境変数対応

### DIFF
--- a/includes/parse.h
+++ b/includes/parse.h
@@ -29,6 +29,7 @@ t_token		*join_redirect(t_token *list);
 bool		is_consecutive_redirect(t_token *list);
 t_token		*trim_list(t_token *list);//
 bool		is_space_after_quot(t_token *list);
+bool		ft_isspace(char c);
 
 // parse tokenlist
 int			parse_tokenlist(t_token *list, unsigned char *status);
@@ -58,6 +59,7 @@ size_t		ft_strlen_excluded_quot(char *str, char *quot);
 bool		is_delimiter(char c);
 char		*ft_strjoin_three(char *str1, char *str2, char *str3);
 bool		is_env_iolist(char flag, t_iolist *prev);
+size_t		get_space_idx(t_cmdlist *clist);
 
 // expansion_utils
 bool		is_delimiter(char c);

--- a/srcs/expansion_cmdlist.c
+++ b/srcs/expansion_cmdlist.c
@@ -59,10 +59,12 @@ static t_cmdlist	*insert_new_cmdlist(t_cmdlist *clist, int i)
 	t_cmdlist	*new;
 	size_t		len;
 
-	new = (t_cmdlist *)ft_xcalloc(1, sizeof(*new));
-	while (clist->str[i] == ' ')
+	while (ft_isspace(clist->str[i]))
 		i++;
 	len = ft_strlen(clist->str + i);
+	if (len == 0)
+		return (clist);
+	new = (t_cmdlist *)ft_xcalloc(1, sizeof(*new));
 	new->str = ft_xsubstr(clist->str, i, len);
 	new->quot = get_quot_flag(new->str);
 	new->next = clist->next;
@@ -73,22 +75,27 @@ static t_cmdlist	*insert_new_cmdlist(t_cmdlist *clist, int i)
 static void	serch_new_space_cmdlist(t_cmdlist *clist)
 {
 	size_t	i;
+	size_t	len;
 	char	*str;
 
-	i = 0;
-	while (clist->str[i])
+	i = get_space_idx(clist);
+	if (i == 0 && ft_isspace(clist->str[i]))
 	{
-		if (clist->str[i] == ' ' && clist->quot[i] == '0')
-		{
-			str = ft_xsubstr(clist->str, 0, i);
-			clist = insert_new_cmdlist(clist, i);
-			xfree(clist->str);
-			xfree(clist->quot);
-			clist->str = str;
-			clist->quot = get_quot_flag(clist->str);
-			i--;
-		}
-		i++;
+		while (ft_isspace(clist->str[i]))
+			i++;
+		len = ft_strlen(clist->str + i);
+		free(clist->str), free(clist->quot);
+		clist->str = ft_xsubstr(clist->str, i, len);
+		clist->quot = get_quot_flag(clist->str);
+		serch_new_space_cmdlist(clist);
+	}
+	else if (ft_isspace(clist->str[i]))
+	{
+		str = ft_xsubstr(clist->str, 0, i);
+		clist = insert_new_cmdlist(clist, i);
+		free(clist->str), free(clist->quot);
+		clist->str = str;
+		clist->quot = get_quot_flag(clist->str);
 	}
 }
 

--- a/srcs/expansion_utils2.c
+++ b/srcs/expansion_utils2.c
@@ -50,3 +50,14 @@ bool	is_delimiter_quot(char c, char flag)
 	else
 		return (false);
 }
+
+size_t	get_space_idx(t_cmdlist *clist)
+{
+	size_t	i;
+
+	i = 0;
+	while (clist->str[i]
+		&& (!ft_isspace(clist->str[i]) || clist->quot[i] != '0'))
+		i++;
+	return (i);
+}

--- a/test/debug_parse.sh
+++ b/test/debug_parse.sh
@@ -96,6 +96,7 @@ test_parse2.c \
 #echo "'"$USER"'"
 
 export VAR="   ramen"
+echo 'VAR="   ramen"' >> result.txt
 
 ./parse 'echo "aa$VAR"' >> result.txt
 
@@ -104,20 +105,12 @@ export VAR="   ramen"
 ### redirect
 ./parse 'echo >$USER' >> result.txt
 
-./parse 'echo >"$USER"' >> result.txt
+export VAR="  aa  bb  "
+echo 'VAR="  aa  bb  "' >> result.txt
 
-./parse 'echo >'\''"$USER"'\' >> result.txt
-#echo '"$VAR"'
+./parse 'echo $VAR' >> result.txt
 
-./parse 'echo >'\'\''$USER'\'\' >> result.txt
-
-./parse 'echo >""$USER""' >> result.txt
-
-./parse 'echo >''"'\''"$USER"'\''"' >> result.txt
-#echo "'"$USER"'"
-
-./parse 'echo >"aa$VAR"' >> result.txt
-
+./parse 'echo XX$VAR' >> result.txt
 
 ### error case
 ./parse 'echo >aa$VAR' >> result.txt 2>&1

--- a/test/result.txt
+++ b/test/result.txt
@@ -352,6 +352,7 @@ execdata[0]
 	  quot: 000000000
 
 
+VAR="   ramen"
 command: [echo "aa$VAR"]
 execdata[0]
 	*status: 0
@@ -397,124 +398,36 @@ execdata[0]
 	  here_doc_fd: -1
 
 
-command: [echo >"$USER"]
+VAR="  aa  bb  "
+command: [echo $VAR]
 execdata[0]
 	*status: 0
 	cmdlist[0]
 	  str: "echo"
 	  quot: 0000
-
-	iolist[0]
-	  str: ">"
-	  quot: 0
-	  c_type: OUT_REDIRECT
-	  here_doc_fd: -1
-
-	iolist[1]
-	  str: ""$USER""
-	  quot: DDDDDD2
-	  c_type: ELSE
-	  here_doc_fd: -1
+	cmdlist[1]
+	  str: "aa"
+	  quot: 00
+	cmdlist[2]
+	  str: "bb"
+	  quot: 00
 
 
-command: [echo >'"$USER"']
+command: [echo XX$VAR]
 execdata[0]
 	*status: 0
 	cmdlist[0]
 	  str: "echo"
 	  quot: 0000
-
-	iolist[0]
-	  str: ">"
-	  quot: 0
-	  c_type: OUT_REDIRECT
-	  here_doc_fd: -1
-
-	iolist[1]
-	  str: "'"$USER"'"
-	  quot: SSSSSSSS1
-	  c_type: ELSE
-	  here_doc_fd: -1
-
-
-command: [echo >''$USER'']
-execdata[0]
-	*status: 0
-	cmdlist[0]
-	  str: "echo"
-	  quot: 0000
-
-	iolist[0]
-	  str: ">"
-	  quot: 0
-	  c_type: OUT_REDIRECT
-	  here_doc_fd: -1
-
-	iolist[1]
-	  str: "''$USER''"
-	  quot: S100000S1
-	  c_type: ELSE
-	  here_doc_fd: -1
-
-
-command: [echo >""$USER""]
-execdata[0]
-	*status: 0
-	cmdlist[0]
-	  str: "echo"
-	  quot: 0000
-
-	iolist[0]
-	  str: ">"
-	  quot: 0
-	  c_type: OUT_REDIRECT
-	  here_doc_fd: -1
-
-	iolist[1]
-	  str: """$USER"""
-	  quot: D200000D2
-	  c_type: ELSE
-	  here_doc_fd: -1
-
-
-command: [echo >"'"$USER"'"]
-execdata[0]
-	*status: 0
-	cmdlist[0]
-	  str: "echo"
-	  quot: 0000
-
-	iolist[0]
-	  str: ">"
-	  quot: 0
-	  c_type: OUT_REDIRECT
-	  here_doc_fd: -1
-
-	iolist[1]
-	  str: ""'"$USER"'""
-	  quot: DD200000DD2
-	  c_type: ELSE
-	  here_doc_fd: -1
-
-
-command: [echo >"aa$VAR"]
-execdata[0]
-	*status: 0
-	cmdlist[0]
-	  str: "echo"
-	  quot: 0000
-
-	iolist[0]
-	  str: ">"
-	  quot: 0
-	  c_type: OUT_REDIRECT
-	  here_doc_fd: -1
-
-	iolist[1]
-	  str: ""aa$VAR""
-	  quot: DDDDDDD2
-	  c_type: ELSE
-	  here_doc_fd: -1
+	cmdlist[1]
+	  str: "XX"
+	  quot: 00
+	cmdlist[2]
+	  str: "aa"
+	  quot: 00
+	cmdlist[3]
+	  str: "bb"
+	  quot: 00
 
 
 command: [echo >aa$VAR]


### PR DESCRIPTION
#54 
主にexpansion_mcdlist.cの`serch_new_space_cmdlist`を変更しました。

valueの前にスペースがある場合に対応するためにif文で２つに分けました。1文字目がスペースだった場合にclist->strにはスペース以降の文字列を入れて再帰してます。
valueの後ろにスペースがある場合に対応するために`insert_new_cmdlist`で新しく作るリストのstrの長さが0だった場合に何もせずreturnするようにしました。
result.txtの401行目~430行目にテスト結果があります。
ちゃんとできてるか不安です。

```
ねこパンチ

(′ω'((⊂(`ω´∩) ポカポカ
```