### PR TITLE
update: expansioin cmdlist

### DIFF
--- a/libft/ft_strlen.c
+++ b/libft/ft_strlen.c
@@ -5,7 +5,7 @@ size_t	ft_strlen(const char *s)
 	size_t	i;
 
 	i = 0;
-	while (s[i])
+	while (s && s[i])
 		i++;
 	return (i);
 }

--- a/srcs/expansion_cmdlist.c
+++ b/srcs/expansion_cmdlist.c
@@ -7,7 +7,7 @@
 ** 3 If there are spaces after expanding, insert new list.
 */
 
-static void	expansion_key_cmdlist(t_cmdlist *clist,
+static size_t	expansion_key_cmdlist(t_cmdlist *clist,
 		t_envlist *envlist, char *doll_ptr)
 {
 	char	*key;
@@ -25,7 +25,9 @@ static void	expansion_key_cmdlist(t_cmdlist *clist,
 	value = ft_getenv(envlist, key);
 	xfree(clist->str);
 	clist->str = ft_strjoin_three(front_key, value, back_key);
+	len = ft_strlen(front_key) + ft_strlen(value);
 	xfree(front_key), xfree(key), xfree(back_key);
+	return (len);
 }
 
 static void	clear_quot_cmdlist(t_cmdlist *clist)
@@ -103,6 +105,7 @@ static void	serch_new_space_cmdlist(t_cmdlist *clist)
 void	serch_env_cmdlist(t_cmdlist *clist, t_envlist *envlist)
 {
 	char	*doll_ptr;
+	size_t	len;
 
 	while (clist)
 	{
@@ -110,10 +113,10 @@ void	serch_env_cmdlist(t_cmdlist *clist, t_envlist *envlist)
 		while (doll_ptr != NULL && clist->quot[doll_ptr - clist->str] != 'S'
 			&& !is_delimiter(*(doll_ptr + 1)))
 		{
-			expansion_key_cmdlist(clist, envlist, doll_ptr);
+			len = expansion_key_cmdlist(clist, envlist, doll_ptr);
 			xfree(clist->quot);
 			clist->quot = get_quot_flag(clist->str);
-			doll_ptr = ft_strdoll(clist->str);
+			doll_ptr = ft_strdoll(clist->str + len);
 		}
 		if (ft_strchr(clist->quot, '1') || ft_strchr(clist->quot, '2'))
 			clear_quot_cmdlist(clist);

--- a/test/debug_parse.sh
+++ b/test/debug_parse.sh
@@ -79,6 +79,17 @@ echo 'VAR="    "' >> result.txt
 
 ./parse 'echo "$VAR"a' >> result.txt
 
+export file=f
+export FILE='$file'
+echo 'file=f' >> result.txt
+echo 'FILE='\''$file'\' >> result.txt
+
+./parse 'echo $FILE' >> result.txt
+
+./parse 'echo $FILE$file' >> result.txt
+
+./parse 'echo $#$HOME' >> result.txt
+
 ### redirect
 ./parse 'echo >$USER' >> result.txt
 

--- a/test/result.txt
+++ b/test/result.txt
@@ -423,6 +423,41 @@ execdata[0]
 	  quot: DDDD0
 
 
+file=f
+FILE='$file'
+command: [echo $FILE]
+execdata[0]
+	*status: 0
+	cmdlist[0]
+	  str: "echo"
+	  quot: 0000
+	cmdlist[1]
+	  str: "$file"
+	  quot: 00000
+
+
+command: [echo $FILE$file]
+execdata[0]
+	*status: 0
+	cmdlist[0]
+	  str: "echo"
+	  quot: 0000
+	cmdlist[1]
+	  str: "$filef"
+	  quot: 000000
+
+
+command: [echo $#$HOME]
+execdata[0]
+	*status: 0
+	cmdlist[0]
+	  str: "echo"
+	  quot: 0000
+	cmdlist[1]
+	  str: "$#/Users/sudourio"
+	  quot: 00000000000000000
+
+
 command: [echo >$USER]
 execdata[0]
 	*status: 0


### PR DESCRIPTION
#55

# expansion_cmdlist.c
`expansion_key_cmdlist()`で`clist->str`の先頭から変数展開後のvalueの後ろまでの長さを返すようにして、whileの中の`ft_strdoll()`ではそのポインタから探すようにしました。
`expansion_key_cmdlist()`内の`ft_strlen()`でvalueがNULLだったときにセグフォするのでft_strlenを変更しました。

# テスト追加
以下のテストを追加しました。
- 環境変数の中に環境変数があった場合
- 展開しない環境変数の次に展開する環境変数があった場合
