### PR TITLE
Mod expandio

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -84,7 +84,7 @@ int			expand_filename(t_iolist *iolist, t_envlist *envlist);
 
 //expansion_io_utils.c
 void		clear_quot_filename(char **filename, char **filequot);
-void		expansion_key_io(char **line, \
+size_t		expansion_key_io(char **line, \
 				t_envlist *envlist, char *doll_ptr);
 char		*ft_strdoll(const char *s);
 

--- a/srcs/expansion_io_utils.c
+++ b/srcs/expansion_io_utils.c
@@ -11,7 +11,7 @@ char	*ft_strdoll(const char *s)
 		return (doll_ptr);
 }
 
-void	expansion_key_io(char **line, \
+size_t	expansion_key_io(char **line, \
 		t_envlist *envlist, char *doll_ptr)
 {
 	char	*key;
@@ -29,7 +29,9 @@ void	expansion_key_io(char **line, \
 	value = ft_getenv(envlist, key);
 	xfree(*line);
 	*line = ft_strjoin_three(front_key, value, back_key);
+	len = ft_strlen(front_key) + ft_strlen(value);
 	xfree(front_key), xfree(key), xfree(back_key);
+	return (len);
 }
 
 void	clear_quot_filename(char **filename, char **filequot)

--- a/srcs/expansion_iolist.c
+++ b/srcs/expansion_iolist.c
@@ -78,6 +78,7 @@ int	expand_filename(t_iolist *iolist, t_envlist *envlist)
 	char		*filename;
 	char		*filequot;
 	int			is_null;
+	size_t		len;
 
 	filename = ft_xstrdup(iolist->str);
 	filequot = get_quot_flag(filename);
@@ -85,10 +86,10 @@ int	expand_filename(t_iolist *iolist, t_envlist *envlist)
 	doll_ptr = ft_strdoll(filename);
 	while (doll_ptr && filequot[doll_ptr - filename] != 'S')
 	{
-		expansion_key_io(&filename, envlist, doll_ptr);
+		len = expansion_key_io(&filename, envlist, doll_ptr);
 		xfree(filequot);
 		filequot = get_quot_flag(filename);
-		doll_ptr = ft_strdoll(filename);
+		doll_ptr = ft_strdoll(filename + len);
 	}
 	if (filename[0] == '\0')
 		is_null++;

--- a/srcs/setdata_heredoc_cmdtype.c
+++ b/srcs/setdata_heredoc_cmdtype.c
@@ -32,12 +32,13 @@ static int	is_cmd_type(t_cmdlist *clst)
 static void	expansion_heredoc(char **line, t_envlist *elst)
 {
 	char	*doll_ptr;
+	size_t	len;
 
 	doll_ptr = ft_strdoll(*line);
 	while (doll_ptr)
 	{
-		expansion_key_io(line, elst, doll_ptr);
-		doll_ptr = ft_strdoll(*line);
+		len = expansion_key_io(line, elst, doll_ptr);
+		doll_ptr = ft_strdoll(*line + len);
 	}
 }
 


### PR DESCRIPTION
iolistの変数展開で、環境変数の中に環境変数があったときに展開しないようにしました。