### PR TITLE
exitせずにエラー処理を行うべき関数を修正、ファイルを整理しました。

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -42,7 +42,7 @@ void		non_builtin(t_execdata *data);
 
 //execution_utils.c
 t_path_type	ft_stat(char *pathname);
-int			ft_dup2(int oldfd, int newfd);
+int			ft_dup2(int oldfd, int newfd, int exit_status);
 int			ft_open(t_iolist *filenode, \
 					int flags, mode_t mode);
 void		execute_command(t_execdata *data);
@@ -67,7 +67,6 @@ void		free_2d_array(char **array);
 char		*ft_xstrjoin(char *str1, char *str2);
 char		**ft_xsplit(char *src_str, char cut_char);
 void		xclose(int fd);
-int			xdup2(int oldfd, int newfd);
 int			xdup(int oldfd);
 
 //wrapper3.c

--- a/includes/execute.h
+++ b/includes/execute.h
@@ -16,6 +16,7 @@ typedef enum e_fd_mode
 {
 	STD_SAVE,
 	STD_RESTORE,
+	FD_SPECIFIED,
 	FD_REDIRECTED,
 	ALL_CLOSE
 }	t_fd_mode;
@@ -46,7 +47,7 @@ int			ft_dup2(int oldfd, int newfd, int exit_status);
 int			ft_open(t_iolist *filenode, \
 					int flags, mode_t mode);
 void		execute_command(t_execdata *data);
-void		open_fd_handler(t_execdata *data, int mode, int redireceted_fd);
+int			redfd_handler(t_execdata *data, t_fd_mode mode, int redireceted_fd);
 
 //env_functions.c
 char		*ft_getenv(t_envlist *elst, char *search_key);
@@ -67,7 +68,7 @@ void		free_2d_array(char **array);
 char		*ft_xstrjoin(char *str1, char *str2);
 char		**ft_xsplit(char *src_str, char cut_char);
 void		xclose(int fd);
-int			xdup(int oldfd);
+int			ft_dup(t_execdata *data, t_stdfd type, int oldfd);
 
 //wrapper3.c
 void		xwaitpid(pid_t pid, int *wstatus, int options);

--- a/includes/execute.h
+++ b/includes/execute.h
@@ -4,23 +4,6 @@
 # include "minishell.h"
 # define FD_MAX 2000
 
-typedef enum e_path_type
-{
-	UNKNOWN,
-	IS_FILE,
-	IS_DIR,
-	ELSE_TYPE
-}	t_path_type;
-
-typedef enum e_fd_mode
-{
-	STD_SAVE,
-	STD_RESTORE,
-	FD_SPECIFIED,
-	FD_REDIRECTED,
-	ALL_CLOSE
-}	t_fd_mode;
-
 //execution_start.c
 int			execute_loop(t_execdata *data);
 void		execute_start(t_execdata *data);
@@ -42,12 +25,9 @@ void		builtin_exit(t_execdata *data);
 void		non_builtin(t_execdata *data);
 
 //execution_utils.c
-t_path_type	ft_stat(char *pathname);
-int			ft_dup2(int oldfd, int newfd, int exit_status);
-int			ft_open(t_iolist *filenode, \
-					int flags, mode_t mode);
+
 void		execute_command(t_execdata *data);
-int			redfd_handler(t_execdata *data, t_fd_mode mode, int redireceted_fd);
+int			redirect_fd_handler(t_execdata *data, t_fd_mode mode, int fd);
 
 //env_functions.c
 char		*ft_getenv(t_envlist *elst, char *search_key);
@@ -68,12 +48,16 @@ void		free_2d_array(char **array);
 char		*ft_xstrjoin(char *str1, char *str2);
 char		**ft_xsplit(char *src_str, char cut_char);
 void		xclose(int fd);
-int			ft_dup(t_execdata *data, t_stdfd type, int oldfd);
+pid_t		xfork(void);
+void		xwaitpid(pid_t pid, int *wstatus, int options);
 
 //wrapper3.c
-void		xwaitpid(pid_t pid, int *wstatus, int options);
-void		xpipe(int *pipefd);
-pid_t		xfork(void);
+int			ft_dup(t_execdata *data, t_stdfd type, int oldfd);
+int			ft_pipe(int *pipefd);
+t_path_type	ft_stat(char *pathname);
+int			ft_dup2(int oldfd, int newfd, int exit_status);
+int			ft_open(t_iolist *filenode, \
+					int flags, mode_t mode);
 
 //minishell_loop.c
 void		minishell_loop(char **envp);

--- a/includes/struct.h
+++ b/includes/struct.h
@@ -42,6 +42,14 @@ typedef enum e_pipefd
 	PIPEFD_NUM
 }	t_pipefd;
 
+typedef enum e_stdfd
+{
+	ORIGINAL_IN,
+	ORIGINAL_OUT,
+	ORIGINAL_ERR,
+	STDFD_NUM
+}	t_stdfd;
+
 typedef struct s_token
 {
 	char			*str;
@@ -77,10 +85,7 @@ typedef struct s_envlist
 typedef struct s_execdata
 {
 	char				**cmdline;
-	int					ori_stdin;
-	int					ori_stdout;
-	int					ori_stderr;
-	int					pipefd[PIPEFD_NUM];
+	int					stdfd[STDFD_NUM];
 	t_cmd				cmd_type;
 	t_cmdlist			*clst;
 	t_iolist			*iolst;

--- a/includes/struct.h
+++ b/includes/struct.h
@@ -50,6 +50,23 @@ typedef enum e_stdfd
 	STDFD_NUM
 }	t_stdfd;
 
+typedef enum e_path_type
+{
+	UNKNOWN,
+	IS_FILE,
+	IS_DIR,
+	ELSE_TYPE
+}	t_path_type;
+
+typedef enum e_fd_mode
+{
+	STD_SAVE,
+	STD_RESTORE,
+	FD_SPECIFIED,
+	FD_REDIRECTED,
+	ALL_CLOSE
+}	t_fd_mode;
+
 typedef struct s_token
 {
 	char			*str;

--- a/srcs/execution_start.c
+++ b/srcs/execution_start.c
@@ -21,6 +21,15 @@ static void	child_execute(t_execdata *data, int prev_pipe_read, \
 static int	parent_connect_fd(t_execdata *data, int prev_pipe_read, \
 						int piperead, int pipewrite)
 {
+	t_iolist	*move;
+
+	move = data->iolst;
+	while (move)
+	{
+		if (move->c_type == IN_HERE_DOC)
+			xclose(move->here_doc_fd);
+		move = move->next;
+	}
 	xclose(pipewrite);
 	if (prev_pipe_read != STDIN_FILENO)
 		xclose(prev_pipe_read);
@@ -106,7 +115,7 @@ void	execute_start(t_execdata *data)
 		g_status = WEXITSTATUS(wstatus);
 		while (data->next)
 		{
-			xwaitpid(0, NULL, 0);
+			wait(NULL);
 			data = data->next;
 		}
 	}

--- a/srcs/execution_start.c
+++ b/srcs/execution_start.c
@@ -9,10 +9,10 @@
 static void	child_execute(t_execdata *data, int prev_pipe_read, \
 						int piperead, int pipewrite)
 {
-	ft_dup2(prev_pipe_read, STDIN_FILENO);
+	ft_dup2(prev_pipe_read, STDIN_FILENO, 1);
 	xclose(piperead);
 	if (data->next)
-		ft_dup2(pipewrite, STDOUT_FILENO);
+		ft_dup2(pipewrite, STDOUT_FILENO, 1);
 	if (setdata_cmdline_redirect(data) == 0)
 		execute_command(data);
 	exit(g_status);
@@ -81,9 +81,9 @@ static void	std_fd_handler(t_execdata *data, int mode)
 	}
 	else if (mode == STD_RESTORE)
 	{
-		ft_dup2(data->ori_stdin, STDIN_FILENO);
-		ft_dup2(data->ori_stdout, STDOUT_FILENO);
-		ft_dup2(data->ori_stderr, STDERR_FILENO);
+		ft_dup2(data->ori_stdin, STDIN_FILENO, 1);
+		ft_dup2(data->ori_stdout, STDOUT_FILENO, 1);
+		ft_dup2(data->ori_stderr, STDERR_FILENO, 1);
 		open_fd_handler(data, ALL_CLOSE, 0);
 	}
 }

--- a/srcs/execution_start.c
+++ b/srcs/execution_start.c
@@ -33,7 +33,7 @@ static int	parent_connect_fd(t_execdata *data, int prev_pipe_read, \
 	xclose(pipewrite);
 	if (prev_pipe_read != STDIN_FILENO)
 		xclose(prev_pipe_read);
-	if (!data->next)
+	if (data->next == NULL)
 		xclose(piperead);
 	return (piperead);
 }
@@ -58,7 +58,7 @@ int	execute_loop(t_execdata *data)
 	prev_pipe_read = STDIN_FILENO;
 	while (data)
 	{
-		xpipe(pipefd);
+		ft_pipe(pipefd);
 		pid = xfork();
 		if (pid == 0)
 			child_execute(data, prev_pipe_read, \
@@ -91,7 +91,7 @@ static int	std_fd_handler(t_execdata *data, t_fd_mode mode)
 		ft_dup2(data->stdfd[ORIGINAL_IN], STDIN_FILENO, 1);
 		ft_dup2(data->stdfd[ORIGINAL_OUT], STDOUT_FILENO, 1);
 		ft_dup2(data->stdfd[ORIGINAL_ERR], STDERR_FILENO, 1);
-		redfd_handler(data, ALL_CLOSE, 0);
+		redirect_fd_handler(data, ALL_CLOSE, 0);
 	}
 	return (ret);
 }

--- a/srcs/execution_utils.c
+++ b/srcs/execution_utils.c
@@ -13,16 +13,26 @@ t_path_type	ft_stat(char *pathname)
 	return (ELSE_TYPE);
 }
 
-int	ft_dup2(int oldfd, int newfd)
+int	ft_dup2(int oldfd, int newfd, int exit_status)
 {
+	int	fd;
+
+	fd = 0;
 	if (oldfd < 0 || newfd < 0)
 		return (-1);
 	if (oldfd != newfd)
 	{
-		xdup2(oldfd, newfd);
+		fd = dup2(oldfd, newfd);
+		if (fd == -1)
+		{
+			ft_putstr_fd("dup2 : ", STDERR_FILENO);
+			ft_putendl_fd(strerror(errno), STDERR_FILENO);
+			if (exit_status)
+				exit(exit_status);
+		}
 		xclose(oldfd);
 	}
-	return (0);
+	return (fd);
 }
 
 int	ft_open(t_iolist *filenode, int flags, mode_t mode)

--- a/srcs/execution_utils.c
+++ b/srcs/execution_utils.c
@@ -71,28 +71,30 @@ void	execute_command(t_execdata *data)
 	cmd_func[data->cmd_type](data);
 }
 
-void	open_fd_handler(t_execdata *data, int mode, int redireceted_fd)
+int	redfd_handler(t_execdata *data, t_fd_mode mode, int fd)
 {
-	static char	open_fd_flag[FD_MAX + 1];
+	static char	redfd_flag[FD_MAX + 1];
 	int			index_fd;
 
-	if (mode == FD_REDIRECTED && !open_fd_flag[redireceted_fd])
+	if (mode == FD_SPECIFIED)
 	{
-		if (data->ori_stdin == redireceted_fd)
-			data->ori_stdin = xdup(redireceted_fd);
-		else if (data->ori_stdout == redireceted_fd)
-			data->ori_stdout = xdup(redireceted_fd);
-		else if (data->ori_stderr == redireceted_fd)
-			data->ori_stderr = xdup(redireceted_fd);
-		open_fd_flag[redireceted_fd]++;
+		if (data->stdfd[ORIGINAL_IN] == fd)
+			return (ft_dup(data, ORIGINAL_IN, fd));
+		else if (data->stdfd[ORIGINAL_OUT] == fd)
+			return (ft_dup(data, ORIGINAL_OUT, fd));
+		else if (data->stdfd[ORIGINAL_ERR] == fd)
+			return (ft_dup(data, ORIGINAL_ERR, fd));
 	}
+	else if (mode == FD_REDIRECTED && !redfd_flag[fd] && STDERR_FILENO < fd)
+		redfd_flag[fd]++;
 	else if (mode == ALL_CLOSE)
 	{
 		index_fd = -1;
 		while (++index_fd <= FD_MAX)
 		{
-			if (open_fd_flag[index_fd])
-				xclose(index_fd), open_fd_flag[index_fd] = 0;
+			if (redfd_flag[index_fd])
+				xclose(index_fd), redfd_flag[index_fd] = 0;
 		}
 	}
+	return (0);
 }

--- a/srcs/execution_utils.c
+++ b/srcs/execution_utils.c
@@ -1,58 +1,5 @@
 #include "minishell.h"
 
-t_path_type	ft_stat(char *pathname)
-{
-	struct stat	sb;
-
-	if (stat(pathname, &sb) == -1)
-		return (UNKNOWN);
-	if ((sb.st_mode & S_IFMT) == S_IFREG)
-		return (IS_FILE);
-	if ((sb.st_mode & S_IFMT) == S_IFDIR)
-		return (IS_DIR);
-	return (ELSE_TYPE);
-}
-
-int	ft_dup2(int oldfd, int newfd, int exit_status)
-{
-	int	fd;
-
-	fd = 0;
-	if (oldfd < 0 || newfd < 0)
-		return (-1);
-	if (oldfd != newfd)
-	{
-		fd = dup2(oldfd, newfd);
-		if (fd == -1)
-		{
-			ft_putstr_fd("dup2 : ", STDERR_FILENO);
-			ft_putendl_fd(strerror(errno), STDERR_FILENO);
-			if (exit_status)
-				exit(exit_status);
-		}
-		xclose(oldfd);
-	}
-	return (fd);
-}
-
-int	ft_open(t_iolist *filenode, int flags, mode_t mode)
-{
-	int	fd;
-
-	if (mode == 0)
-		fd = open(filenode->str, flags);
-	else
-		fd = open(filenode->str, flags, mode);
-	if (fd == -1)
-	{
-		ft_putstr_fd("open: ", STDERR_FILENO);
-		ft_putstr_fd(filenode->str, STDERR_FILENO);
-		ft_putstr_fd(": ", STDERR_FILENO);
-		perror("");
-	}
-	return (fd);
-}
-
 void	execute_command(t_execdata *data)
 {
 	void	(*cmd_func[CMD_NUM])(t_execdata *data);
@@ -71,7 +18,7 @@ void	execute_command(t_execdata *data)
 	cmd_func[data->cmd_type](data);
 }
 
-int	redfd_handler(t_execdata *data, t_fd_mode mode, int fd)
+int	redirect_fd_handler(t_execdata *data, t_fd_mode mode, int fd)
 {
 	static char	redfd_flag[FD_MAX + 1];
 	int			index_fd;
@@ -85,7 +32,8 @@ int	redfd_handler(t_execdata *data, t_fd_mode mode, int fd)
 		else if (data->stdfd[ORIGINAL_ERR] == fd)
 			return (ft_dup(data, ORIGINAL_ERR, fd));
 	}
-	else if (mode == FD_REDIRECTED && !redfd_flag[fd] && STDERR_FILENO < fd)
+	else if (mode == FD_REDIRECTED && \
+				!redfd_flag[fd] && STDERR_FILENO < fd)
 		redfd_flag[fd]++;
 	else if (mode == ALL_CLOSE)
 	{

--- a/srcs/setdata_cmdline_redirection.c
+++ b/srcs/setdata_cmdline_redirection.c
@@ -35,16 +35,16 @@ static int	redirection(t_execdata *data, t_iolist *iolst, \
 	int	ret;
 
 	ret = expand_filename(iolst->next, data->elst);
-	if (ret == 0 && iolst->c_type == IN_REDIRECT)
-		ret = ft_dup2(ft_open(iolst->next, O_RDONLY, 0), redirected_fd);
-	else if (ret == 0 && iolst->c_type == IN_HERE_DOC)
-		ret = ft_dup2(iolst->here_doc_fd, redirected_fd);
-	else if (ret == 0 && iolst->c_type == OUT_REDIRECT)
+	if (ret != -1 && iolst->c_type == IN_REDIRECT)
+		ret = ft_dup2(ft_open(iolst->next, O_RDONLY, 0), redirected_fd, 0);
+	else if (ret != -1 && iolst->c_type == IN_HERE_DOC)
+		ret = ft_dup2(iolst->here_doc_fd, redirected_fd, 0);
+	else if (ret != -1 && iolst->c_type == OUT_REDIRECT)
 		ret = ft_dup2(ft_open(iolst->next, O_WRONLY | O_CREAT | O_TRUNC, 0666), \
-						redirected_fd);
-	else if (ret == 0 && iolst->c_type == OUT_HERE_DOC)
+						redirected_fd, 0);
+	else if (ret != -1 && iolst->c_type == OUT_HERE_DOC)
 		ret = ft_dup2(ft_open(iolst->next, O_WRONLY | O_CREAT | O_APPEND, 0666), \
-						redirected_fd);
+						redirected_fd, 0);
 	*is_fd_specified = 0;
 	return (ret);
 }
@@ -60,10 +60,10 @@ int	setdata_cmdline_redirect(t_execdata *data)
 	ret = 0;
 	is_fd_specified = 0;
 	move = data->iolst;
-	while (ret == 0 && move)
+	while (ret != -1 && move)
 	{
 		ret = set_redirected_fd(data, move, &redirected_fd, &is_fd_specified);
-		if (ret == 0 && \
+		if (ret != -1 && \
 			IN_REDIRECT <= move->c_type && move->c_type <= OUT_HERE_DOC)
 			ret = redirection(data, move, \
 					redirected_fd, &is_fd_specified);

--- a/srcs/setdata_cmdline_redirection.c
+++ b/srcs/setdata_cmdline_redirection.c
@@ -17,7 +17,7 @@ static int	set_redirect_fd(t_execdata *data, t_iolist *iolst, \
 			ft_putendl_fd("bad file descriptor", STDERR_FILENO);
 			return (-1);
 		}
-		if (redfd_handler(data, FD_SPECIFIED, *redirect_fd) == -1)
+		if (redirect_fd_handler(data, FD_SPECIFIED, *redirect_fd) == -1)
 			return (-1);
 		*is_fd_specified = 1;
 	}
@@ -47,7 +47,7 @@ static int	redirection(t_execdata *data, t_iolist *iolst, \
 		ret = ft_dup2(ft_open(iolst->next, O_WRONLY | O_CREAT | O_APPEND, 0666), \
 						redirect_fd, 0);
 	if (ret != -1)
-		redfd_handler(data, FD_REDIRECTED, redirect_fd);
+		redirect_fd_handler(data, FD_REDIRECTED, redirect_fd);
 	*is_fd_specified = 0;
 	return (ret);
 }

--- a/srcs/setdata_cmdline_redirection.c
+++ b/srcs/setdata_cmdline_redirection.c
@@ -6,45 +6,48 @@
 ** 2 Redirection.
 */
 
-static int	set_redirected_fd(t_execdata *data, t_iolist *iolst, \
-							int *redirected_fd, int *is_fd_specified)
+static int	set_redirect_fd(t_execdata *data, t_iolist *iolst, \
+							int *redirect_fd, int *is_fd_specified)
 {
 	if (iolst->c_type == FD)
 	{
-		*redirected_fd = ft_atoi(iolst->str);
-		if (*redirected_fd < 0 || FD_MAX < *redirected_fd)
+		*redirect_fd = ft_atoi(iolst->str);
+		if (*redirect_fd < 0 || FD_MAX < *redirect_fd)
 		{
 			ft_putendl_fd("bad file descriptor", STDERR_FILENO);
 			return (-1);
 		}
-		open_fd_handler(data, FD_REDIRECTED, *redirected_fd);
+		if (redfd_handler(data, FD_SPECIFIED, *redirect_fd) == -1)
+			return (-1);
 		*is_fd_specified = 1;
 	}
 	else if (*is_fd_specified == 0 && \
 		(iolst->c_type == IN_REDIRECT || iolst->c_type == IN_HERE_DOC))
-		*redirected_fd = STDIN_FILENO;
+		*redirect_fd = STDIN_FILENO;
 	else if (*is_fd_specified == 0 && \
 		(iolst->c_type == OUT_REDIRECT || iolst->c_type == OUT_HERE_DOC))
-		*redirected_fd = STDOUT_FILENO;
+		*redirect_fd = STDOUT_FILENO;
 	return (0);
 }
 
 static int	redirection(t_execdata *data, t_iolist *iolst, \
-					int redirected_fd, int *is_fd_specified)
+					int redirect_fd, int *is_fd_specified)
 {
 	int	ret;
 
 	ret = expand_filename(iolst->next, data->elst);
 	if (ret != -1 && iolst->c_type == IN_REDIRECT)
-		ret = ft_dup2(ft_open(iolst->next, O_RDONLY, 0), redirected_fd, 0);
+		ret = ft_dup2(ft_open(iolst->next, O_RDONLY, 0), redirect_fd, 0);
 	else if (ret != -1 && iolst->c_type == IN_HERE_DOC)
-		ret = ft_dup2(iolst->here_doc_fd, redirected_fd, 0);
+		ret = ft_dup2(iolst->here_doc_fd, redirect_fd, 0);
 	else if (ret != -1 && iolst->c_type == OUT_REDIRECT)
 		ret = ft_dup2(ft_open(iolst->next, O_WRONLY | O_CREAT | O_TRUNC, 0666), \
-						redirected_fd, 0);
+						redirect_fd, 0);
 	else if (ret != -1 && iolst->c_type == OUT_HERE_DOC)
 		ret = ft_dup2(ft_open(iolst->next, O_WRONLY | O_CREAT | O_APPEND, 0666), \
-						redirected_fd, 0);
+						redirect_fd, 0);
+	if (ret != -1)
+		redfd_handler(data, FD_REDIRECTED, redirect_fd);
 	*is_fd_specified = 0;
 	return (ret);
 }
@@ -53,7 +56,7 @@ int	setdata_cmdline_redirect(t_execdata *data)
 {
 	int			ret;
 	t_iolist	*move;
-	int			redirected_fd;
+	int			redirect_fd;
 	int			is_fd_specified;
 
 	data->cmdline = convert_cmdlist_2dchar(data->clst);
@@ -62,11 +65,11 @@ int	setdata_cmdline_redirect(t_execdata *data)
 	move = data->iolst;
 	while (ret != -1 && move)
 	{
-		ret = set_redirected_fd(data, move, &redirected_fd, &is_fd_specified);
+		ret = set_redirect_fd(data, move, &redirect_fd, &is_fd_specified);
 		if (ret != -1 && \
 			IN_REDIRECT <= move->c_type && move->c_type <= OUT_HERE_DOC)
 			ret = redirection(data, move, \
-					redirected_fd, &is_fd_specified);
+					redirect_fd, &is_fd_specified);
 		move = move->next;
 	}
 	if (ret == -1)

--- a/srcs/setdata_heredoc_cmdtype.c
+++ b/srcs/setdata_heredoc_cmdtype.c
@@ -7,7 +7,7 @@
 ** 2 get command type of each data.
 */
 
-static int	is_cmd_type(t_cmdlist *clst)
+static t_cmd	is_cmd_type(t_cmdlist *clst)
 {
 	if (clst == NULL)
 		return (NON_CMD);
@@ -42,7 +42,7 @@ static void	expansion_heredoc(char **line, t_envlist *elst)
 	}
 }
 
-static t_cmd	get_here_doc(char *limiter, t_execdata *data, int is_quot)
+static int	get_here_doc(char *limiter, t_execdata *data, int is_quot)
 {
 	char	*line;
 	int		pipefd[PIPEFD_NUM];

--- a/srcs/setdata_heredoc_cmdtype.c
+++ b/srcs/setdata_heredoc_cmdtype.c
@@ -48,9 +48,9 @@ static int	get_here_doc(char *limiter, t_execdata *data, int is_quot)
 	int		pipefd[PIPEFD_NUM];
 	int		no_limit;
 
-	xpipe(pipefd);
+	ft_pipe(pipefd);
 	no_limit = 1;
-	while (no_limit)
+	while (no_limit && pipefd[WRITE] != -1)
 	{
 		line = readline("> ");
 		if (!line)

--- a/srcs/wrapper2.c
+++ b/srcs/wrapper2.c
@@ -36,7 +36,7 @@ void	xclose(int fd)
 	}
 }
 
-int	xdup(int oldfd)
+int	ft_dup(t_execdata *data, t_stdfd type, int oldfd)
 {
 	int	newfd;
 
@@ -45,7 +45,8 @@ int	xdup(int oldfd)
 	{
 		ft_putstr_fd("dup : ", STDERR_FILENO);
 		ft_putendl_fd(strerror(errno), STDERR_FILENO);
-		exit(EXIT_FAILURE);
 	}
+	else
+		data->stdfd[type] = newfd;
 	return (newfd);
 }

--- a/srcs/wrapper2.c
+++ b/srcs/wrapper2.c
@@ -28,7 +28,7 @@ char	**ft_xsplit(char *src_str, char cut_char)
 
 void	xclose(int fd)
 {
-	if (close(fd) == -1)
+	if (0 <= fd && close(fd) == -1)
 	{
 		ft_putstr_fd("close : ", STDERR_FILENO);
 		ft_putendl_fd(strerror(errno), STDERR_FILENO);
@@ -36,17 +36,24 @@ void	xclose(int fd)
 	}
 }
 
-int	ft_dup(t_execdata *data, t_stdfd type, int oldfd)
+pid_t	xfork(void)
 {
-	int	newfd;
+	int	pid;
 
-	newfd = dup(oldfd);
-	if (newfd == -1)
+	pid = fork();
+	if (pid == -1)
 	{
-		ft_putstr_fd("dup : ", STDERR_FILENO);
-		ft_putendl_fd(strerror(errno), STDERR_FILENO);
+		perror("fork");
+		exit(EXIT_FAILURE);
 	}
-	else
-		data->stdfd[type] = newfd;
-	return (newfd);
+	return (pid);
+}
+
+void	xwaitpid(pid_t pid, int *wstatus, int options)
+{
+	if (waitpid(pid, wstatus, options) == -1)
+	{
+		perror("waitpid");
+		exit(EXIT_FAILURE);
+	}
 }

--- a/srcs/wrapper2.c
+++ b/srcs/wrapper2.c
@@ -36,20 +36,6 @@ void	xclose(int fd)
 	}
 }
 
-int	xdup2(int oldfd, int newfd)
-{
-	int	fd;
-
-	fd = dup2(oldfd, newfd);
-	if (fd == -1)
-	{
-		ft_putstr_fd("dup2 : ", STDERR_FILENO);
-		ft_putendl_fd(strerror(errno), STDERR_FILENO);
-		exit(EXIT_FAILURE);
-	}
-	return (fd);
-}
-
 int	xdup(int oldfd)
 {
 	int	newfd;

--- a/srcs/wrapper3.c
+++ b/srcs/wrapper3.c
@@ -1,32 +1,81 @@
 #include "minishell.h"
 
-void	xwaitpid(pid_t pid, int *wstatus, int options)
-{
-	if (waitpid(pid, wstatus, options) == -1)
-	{
-		perror("waitpid");
-		exit(EXIT_FAILURE);
-	}
-}
-
-void	xpipe(int *pipefd)
+int	ft_pipe(int *pipefd)
 {
 	if (pipe(pipefd) == -1)
 	{
 		perror("pipe");
-		exit(EXIT_FAILURE);
+		pipefd[READ] = -1;
+		pipefd[WRITE] = -1;
+		return (-1);
 	}
+	return (0);
 }
 
-pid_t	xfork(void)
+int	ft_dup(t_execdata *data, t_stdfd type, int oldfd)
 {
-	int	pid;
+	int	newfd;
 
-	pid = fork();
-	if (pid == -1)
+	newfd = dup(oldfd);
+	if (newfd == -1)
 	{
-		perror("fork");
-		exit(EXIT_FAILURE);
+		ft_putstr_fd("dup : ", STDERR_FILENO);
+		ft_putendl_fd(strerror(errno), STDERR_FILENO);
 	}
-	return (pid);
+	else
+		data->stdfd[type] = newfd;
+	return (newfd);
+}
+
+int	ft_dup2(int oldfd, int newfd, int exit_status)
+{
+	int	fd;
+
+	fd = 0;
+	if (oldfd < 0 || newfd < 0)
+		return (-1);
+	if (oldfd != newfd)
+	{
+		fd = dup2(oldfd, newfd);
+		if (fd == -1)
+		{
+			ft_putstr_fd("dup2 : ", STDERR_FILENO);
+			ft_putendl_fd(strerror(errno), STDERR_FILENO);
+			if (exit_status)
+				exit(exit_status);
+		}
+		xclose(oldfd);
+	}
+	return (fd);
+}
+
+t_path_type	ft_stat(char *pathname)
+{
+	struct stat	sb;
+
+	if (stat(pathname, &sb) == -1)
+		return (UNKNOWN);
+	if ((sb.st_mode & S_IFMT) == S_IFREG)
+		return (IS_FILE);
+	if ((sb.st_mode & S_IFMT) == S_IFDIR)
+		return (IS_DIR);
+	return (ELSE_TYPE);
+}
+
+int	ft_open(t_iolist *filenode, int flags, mode_t mode)
+{
+	int	fd;
+
+	if (mode == 0)
+		fd = open(filenode->str, flags);
+	else
+		fd = open(filenode->str, flags, mode);
+	if (fd == -1)
+	{
+		ft_putstr_fd("open: ", STDERR_FILENO);
+		ft_putstr_fd(filenode->str, STDERR_FILENO);
+		ft_putstr_fd(": ", STDERR_FILENO);
+		perror("");
+	}
+	return (fd);
 }


### PR DESCRIPTION
何故か昨日の終了ステータスの変更も反映されてます。。
### extiせずに返り値処理をするようにした関数
- xpipe->ft_pipe
- ft_dup2(xdup2削除)
- xdup->ft_dup
### 伴って変更したこと
- 返り値の型が変更されている関数たちは、上記で変更した関数に合わせて返り値を返すように修正しました。
- execdataメンバー
pipefdを削除、ori_stdin系をstdfd[]として配列で管理（各要素はe_stdfd指定)
- open_fd_handler()->redirect_fd_handler()、リダイレクト時に動く関数
    - FD_SPECIFIED->指定されたfdが標準入出力の保存fdと被りがないか確認
    - FD_REDIRECTED->指定されたfdがリダイレクトされたので、開いているフラグを立てる
    - ALL_CLOSE->あけたfdを閉じる
- ヘッダーの整理とファイルの整理