### PR TITLE
ヒアドキュメントを子プロセスで受け取ります。

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -12,7 +12,7 @@ void		execute_start(t_execdata *data);
 int			setdata_cmdline_redirect(t_execdata *data);
 
 //setdata_heredoc_cmdtype.c
-void		setdata_heredoc_cmdtype(t_execdata *data);
+int			setdata_heredoc_cmdtype(t_execdata *data);
 
 //command_*.c
 void		builtin_echo(t_execdata *data);

--- a/srcs/execution_start.c
+++ b/srcs/execution_start.c
@@ -21,15 +21,15 @@ static void	child_execute(t_execdata *data, int prev_pipe_read, \
 static int	parent_connect_fd(t_execdata *data, int prev_pipe_read, \
 						int piperead, int pipewrite)
 {
-	t_iolist	*move;
+	// t_iolist	*move;
 
-	move = data->iolst;
-	while (move)
-	{
-		if (move->c_type == IN_HERE_DOC)
-			xclose(move->here_doc_fd);
-		move = move->next;
-	}
+	// move = data->iolst;
+	// while (move)
+	// {
+	// 	if (move->c_type == IN_HERE_DOC)
+	// 		xclose(move->here_doc_fd);
+	// 	move = move->next;
+	// }
 	xclose(pipewrite);
 	if (prev_pipe_read != STDIN_FILENO)
 		xclose(prev_pipe_read);
@@ -107,7 +107,8 @@ void	execute_start(t_execdata *data)
 	int			lastchild_pid;
 	int			wstatus;
 
-	setdata_heredoc_cmdtype(data);
+	if (setdata_heredoc_cmdtype(data) == -1)
+		return ;
 	if (data->next == NULL && data->cmd_type != OTHER)
 	{
 		if (std_fd_handler(data, STD_SAVE) != -1 && \

--- a/srcs/setdata_cmdline_redirection.c
+++ b/srcs/setdata_cmdline_redirection.c
@@ -39,7 +39,10 @@ static int	redirection(t_execdata *data, t_iolist *iolst, \
 	if (ret != -1 && iolst->c_type == IN_REDIRECT)
 		ret = ft_dup2(ft_open(iolst->next, O_RDONLY, 0), redirect_fd, 0);
 	else if (ret != -1 && iolst->c_type == IN_HERE_DOC)
+	{
 		ret = ft_dup2(iolst->here_doc_fd, redirect_fd, 0);
+		iolst->here_doc_fd = -1;
+	}
 	else if (ret != -1 && iolst->c_type == OUT_REDIRECT)
 		ret = ft_dup2(ft_open(iolst->next, O_WRONLY | O_CREAT | O_TRUNC, 0666), \
 						redirect_fd, 0);


### PR DESCRIPTION
#77 
### 変更点
- setdata_heredoc_cmdtype.c
    - get_here_doc()->子プロセスを生成して、ヒアドキュメントをchild_get_here_doc()で受け取る
    - get_here_doc()->child_get_here_doc()の終了ステータスを見て成功したか、してないか判断します
    - child_get_here_doc()->(基本的に以前のget_here_doc()と変わらないが)lineがNULLの時(Ctrl + D)にexitさせずにbreakさせます=プログラム自体ではなく受け取りを終了させる。
- その他
minishell起動中、いくつかヒアドキュメントを受け取っている途中で中断された場合、それまでの開いたPIPEのfdを閉じなければなりません。
今までは各所で閉じていましたが、統一するためにclear_list系で閉じたいと思っています。
なので今回変更した中でhere_doc_fdを閉じる作業をコメントアウトしたり、here_doc_fdに-1を入れているのはそのためです。

### 今後やりたいこと
- data->std[]、iolist->here_doc_fdの初期化。
- clear_list系でiolist->here_doc_fdを閉じる、data->cmdlineのfreeをする。