### PR TITLE
実行ファイルの探し方を変えました。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ SRCS_NAME = main.c \
 			tokenize_utils.c \
 			wrapper1.c \
 			wrapper2.c \
-			wrapper3.c
+			wrapper3.c \
+			wrapper4.c
 
 SRCS = ${addprefix ${SRCS_DIR}, ${SRCS_NAME}}
 

--- a/includes/execute.h
+++ b/includes/execute.h
@@ -12,7 +12,7 @@ void		execute_start(t_execdata *data);
 int			setdata_cmdline_redirect(t_execdata *data);
 
 //setdata_heredoc_cmdtype.c
-void		setdata_heredoc_cmdtype(t_execdata *data);
+int			setdata_heredoc_cmdtype(t_execdata *data);
 
 //command_*.c
 void		builtin_echo(t_execdata *data);

--- a/includes/execute.h
+++ b/includes/execute.h
@@ -59,6 +59,9 @@ int			ft_dup2(int oldfd, int newfd, int exit_status);
 int			ft_open(t_iolist *filenode, \
 					int flags, mode_t mode);
 
+//wrapper4.c
+void		ft_perror(char *perror_str);
+
 //minishell_loop.c
 void		minishell_loop(char **envp);
 

--- a/includes/struct.h
+++ b/includes/struct.h
@@ -53,7 +53,8 @@ typedef enum e_stdfd
 typedef enum e_path_type
 {
 	UNKNOWN,
-	IS_FILE,
+	EXECUTABLE,
+	UN_EXECUTABLE,
 	IS_DIR,
 	ELSE_TYPE
 }	t_path_type;

--- a/srcs/execution_start.c
+++ b/srcs/execution_start.c
@@ -21,15 +21,15 @@ static void	child_execute(t_execdata *data, int prev_pipe_read, \
 static int	parent_connect_fd(t_execdata *data, int prev_pipe_read, \
 						int piperead, int pipewrite)
 {
-	t_iolist	*move;
+	// t_iolist	*move;
 
-	move = data->iolst;
-	while (move)
-	{
-		if (move->c_type == IN_HERE_DOC)
-			xclose(move->here_doc_fd);
-		move = move->next;
-	}
+	// move = data->iolst;
+	// while (move)
+	// {
+	// 	if (move->c_type == IN_HERE_DOC)
+	// 		xclose(move->here_doc_fd);
+	// 	move = move->next;
+	// }
 	xclose(pipewrite);
 	if (prev_pipe_read != STDIN_FILENO)
 		xclose(prev_pipe_read);
@@ -107,7 +107,8 @@ void	execute_start(t_execdata *data)
 	int			lastchild_pid;
 	int			wstatus;
 
-	setdata_heredoc_cmdtype(data);
+	if (setdata_heredoc_cmdtype(data) == -1)
+		return ;
 	if (data->next == NULL && data->cmd_type != OTHER)
 	{
 		if (std_fd_handler(data, STD_SAVE) != -1 && \

--- a/srcs/setdata_cmdline_redirection.c
+++ b/srcs/setdata_cmdline_redirection.c
@@ -39,7 +39,10 @@ static int	redirection(t_execdata *data, t_iolist *iolst, \
 	if (ret != -1 && iolst->c_type == IN_REDIRECT)
 		ret = ft_dup2(ft_open(iolst->next, O_RDONLY, 0), redirect_fd, 0);
 	else if (ret != -1 && iolst->c_type == IN_HERE_DOC)
+	{
 		ret = ft_dup2(iolst->here_doc_fd, redirect_fd, 0);
+		iolst->here_doc_fd = -1;
+	}
 	else if (ret != -1 && iolst->c_type == OUT_REDIRECT)
 		ret = ft_dup2(ft_open(iolst->next, O_WRONLY | O_CREAT | O_TRUNC, 0666), \
 						redirect_fd, 0);

--- a/srcs/wrapper3.c
+++ b/srcs/wrapper3.c
@@ -56,7 +56,11 @@ t_path_type	ft_stat(char *pathname)
 	if (stat(pathname, &sb) == -1)
 		return (UNKNOWN);
 	if ((sb.st_mode & S_IFMT) == S_IFREG)
-		return (IS_FILE);
+	{
+		if (sb.st_mode & S_IXUSR)
+			return (EXECUTABLE);
+		return (UN_EXECUTABLE);
+	}
 	if ((sb.st_mode & S_IFMT) == S_IFDIR)
 		return (IS_DIR);
 	return (ELSE_TYPE);

--- a/srcs/wrapper4.c
+++ b/srcs/wrapper4.c
@@ -1,0 +1,7 @@
+#include "minishell.h"
+
+void	ft_perror(char *perror_str)
+{
+	ft_putstr_fd("minishell: ", STDERR_FILENO);
+	perror(perror_str);
+}


### PR DESCRIPTION
#79 
ブランチの切り方変えてみたんですが、他のブランチのpushの反映されてるみたいです。。
実行権限のあるファイルが見つかるまでPATHからファイルを探す作業を追加しました。
### ここで見て欲しいのは以下です。
- struct.h内、e_path_typeのIS_FILEをEXECUTABLEとUN_EXEUTABLEの二つに変更しました。
- 上記により、wrapper3.c内のft_stat()で、ファイルがあった場合にそれが実行ファイルなのかどうかまで返り値を分けることができます。
- 上記により、command_nonbuiltin.c内で出力するエラー文の(ファイルは存在するが実行権限がなかった場合の)条件分岐が増えたので、関数を増やしてまとめるようにしました。