### PR TITLE
初期化作業とcler_list系の追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ HEADER_DIR = ./includes
 
 LIBFT_DIR = ./libft
 
-READLINE_DIR = /usr/local/opt/readline
+READLINE_DIR = $(shell brew --prefix readline)
 
 OBJS = ${SRCS:.c=.o}
 

--- a/includes/execute.h
+++ b/includes/execute.h
@@ -61,6 +61,7 @@ int			ft_open(t_iolist *filenode, \
 
 //wrapper4.c
 void		ft_perror(char *perror_str);
+void		ft_puterror(char *str1, char *str2, char *str3);
 
 //minishell_loop.c
 void		minishell_loop(char **envp);

--- a/srcs/clear_list.c
+++ b/srcs/clear_list.c
@@ -52,6 +52,7 @@ void	clear_iolist(t_iolist *list)
 	while (list)
 	{
 		next = list->next;
+		xclose(list->here_doc_fd);
 		xfree(list->str);
 		xfree(list->quot);
 		xfree(list);
@@ -68,6 +69,7 @@ void	clear_execdata(t_execdata *data)
 		next = data->next;
 		clear_cmdlist(data->clst);
 		clear_iolist(data->iolst);
+		free_2d_array(data->cmdline);
 		xfree(data);
 		data = next;
 	}

--- a/srcs/command_builtin1.c
+++ b/srcs/command_builtin1.c
@@ -14,7 +14,7 @@ void	builtin_echo(t_execdata *data)
 
 	if (write(STDOUT_FILENO, NULL, 0) == -1)
 	{
-		perror("echo: write error");
+		ft_perror("echo: write error");
 		g_status = 1;
 		return ;
 	}
@@ -42,7 +42,7 @@ void	builtin_cd(t_execdata *data)
 		data->cmdline[1][0] && \
 		chdir(data->cmdline[1]) == -1)
 	{
-		perror("cd");
+		ft_perror("cd");
 		g_status = 1;
 		return ;
 	}
@@ -57,14 +57,14 @@ void	builtin_pwd(t_execdata *data)
 
 	if (write(STDOUT_FILENO, NULL, 0) == -1)
 	{
-		perror("pwd: write error");
+		ft_perror("pwd: write error");
 		g_status = 1;
 		return ;
 	}
 	pathname = getcwd(NULL, 0);
 	if (!pathname)
 	{
-		perror("pwd");
+		ft_perror("pwd");
 		g_status = 1;
 	}
 	else

--- a/srcs/command_builtin2.c
+++ b/srcs/command_builtin2.c
@@ -98,9 +98,8 @@ void	builtin_export(t_execdata *data)
 				to_setenv(data->elst, data->cmdline[arg_i], split_point);
 			else
 			{
-				ft_putstr_fd("minishell: export: ", STDERR_FILENO);
-				ft_putstr_fd(data->cmdline[arg_i], STDERR_FILENO);
-				ft_putendl_fd(": not a valid identifier", STDERR_FILENO);
+				ft_puterror("export", data->cmdline[arg_i], \
+									"not a valid identifier");
 				g_status = 1;
 			}
 			arg_i++;

--- a/srcs/command_builtin3.c
+++ b/srcs/command_builtin3.c
@@ -43,16 +43,15 @@ void	builtin_exit(t_execdata *data)
 		exit(0);
 	if (data->cmdline[2])
 	{
-		ft_putstr_fd("minishell: exit: too many arguments\n", STDERR_FILENO);
+		ft_puterror("exit", "too many arguments", NULL);
 		g_status = 1;
 		return ;
 	}
 	g_status = (unsigned char)ft_atol(data->cmdline[1], &nonnum_check);
 	if (nonnum_check)
 	{
-		ft_putstr_fd("minishell: exit: ", STDERR_FILENO);
-		ft_putstr_fd(data->cmdline[1], STDERR_FILENO);
-		ft_putendl_fd(": numeric argument required", STDERR_FILENO);
+		ft_puterror("exit", data->cmdline[1], \
+						"numeric argument required");
 		g_status = 255;
 	}
 	exit(g_status);

--- a/srcs/command_nonbuiltin.c
+++ b/srcs/command_nonbuiltin.c
@@ -11,10 +11,7 @@
 
 static void	result_of_search(char *cmd, char *str, int status)
 {
-	ft_putstr_fd("minishell: ", STDERR_FILENO);
-	ft_putstr_fd(cmd, STDERR_FILENO);
-	ft_putstr_fd(": ", STDERR_FILENO);
-	ft_putendl_fd(str, STDERR_FILENO);
+	ft_puterror(cmd, str, NULL);
 	g_status = status;
 }
 
@@ -122,6 +119,6 @@ void	non_builtin(t_execdata *data)
 		exit(g_status);
 	if (execve(cmd_path, data->cmdline, \
 		convert_envlist_2dchar(data->elst)) == -1)
-		perror(data->cmdline[0]);
+		ft_perror(data->cmdline[0]);
 	g_status = 126;
 }

--- a/srcs/execdata.c
+++ b/srcs/execdata.c
@@ -55,6 +55,9 @@ static t_execdata	*new_execdata(t_execdata *cur, t_token *start,
 
 	new = (t_execdata *)ft_xcalloc(1, sizeof(*new));
 	new->cmdline = NULL;
+	new->stdfd[ORIGINAL_IN] = -1;
+	new->stdfd[ORIGINAL_OUT] = -1;
+	new->stdfd[ORIGINAL_ERR] = -1;
 	new->clst = get_clst(start, cur_token);
 	new->iolst = get_iolst(start, cur_token);
 	new->elst = envlist;

--- a/srcs/execdata_utils.c
+++ b/srcs/execdata_utils.c
@@ -73,7 +73,6 @@ t_iolist	*new_iolst(t_iolist *cur, t_token *token)
 	new = (t_iolist *)ft_xcalloc(1, sizeof(*new));
 	new->here_doc_fd = -1;
 	new->c_type = token->special;
-	new->here_doc_fd = -1;
 	cur->next = new;
 	new->str = ft_xstrdup(token->str);
 	new->quot = get_quot_flag(new->str);

--- a/srcs/execution_start.c
+++ b/srcs/execution_start.c
@@ -21,15 +21,6 @@ static void	child_execute(t_execdata *data, int prev_pipe_read, \
 static int	parent_connect_fd(t_execdata *data, int prev_pipe_read, \
 						int piperead, int pipewrite)
 {
-	// t_iolist	*move;
-
-	// move = data->iolst;
-	// while (move)
-	// {
-	// 	if (move->c_type == IN_HERE_DOC)
-	// 		xclose(move->here_doc_fd);
-	// 	move = move->next;
-	// }
 	xclose(pipewrite);
 	if (prev_pipe_read != STDIN_FILENO)
 		xclose(prev_pipe_read);
@@ -114,7 +105,6 @@ void	execute_start(t_execdata *data)
 		if (std_fd_handler(data, STD_SAVE) != -1 && \
 				setdata_cmdline_redirect(data) != -1)
 			execute_command(data);
-		free_2d_array(data->cmdline);
 		std_fd_handler(data, STD_RESTORE);
 	}
 	else

--- a/srcs/expansion_iolist.c
+++ b/srcs/expansion_iolist.c
@@ -58,9 +58,7 @@ static int	check_filename(t_iolist *iolist, \
 	filename = rm_isspace(filename, filequot);
 	if (!filename || is_null)
 	{
-		ft_putstr_fd("minishell: ", STDERR_FILENO);
-		ft_putstr_fd(iolist->str, STDERR_FILENO);
-		ft_putendl_fd(": ambiguous redirect", STDERR_FILENO);
+		ft_puterror(iolist->str, "ambiguous redirect", NULL);
 		free(filename);
 		free(filequot);
 		return (-1);

--- a/srcs/setdata_cmdline_redirection.c
+++ b/srcs/setdata_cmdline_redirection.c
@@ -73,9 +73,11 @@ int	setdata_cmdline_redirect(t_execdata *data)
 			IN_REDIRECT <= move->c_type && move->c_type <= OUT_HERE_DOC)
 			ret = redirection(data, move, \
 					redirect_fd, &is_fd_specified);
+		if (ret == -1)
+			g_status = 1;
+		else
+			g_status = 0;
 		move = move->next;
 	}
-	if (ret == -1)
-		g_status = 1;
 	return (ret);
 }

--- a/srcs/wrapper2.c
+++ b/srcs/wrapper2.c
@@ -30,8 +30,7 @@ void	xclose(int fd)
 {
 	if (0 <= fd && close(fd) == -1)
 	{
-		ft_putstr_fd("close : ", STDERR_FILENO);
-		ft_putendl_fd(strerror(errno), STDERR_FILENO);
+		perror("close");
 		exit(EXIT_FAILURE);
 	}
 }

--- a/srcs/wrapper3.c
+++ b/srcs/wrapper3.c
@@ -18,10 +18,7 @@ int	ft_dup(t_execdata *data, t_stdfd type, int oldfd)
 
 	newfd = dup(oldfd);
 	if (newfd == -1)
-	{
-		ft_putstr_fd("dup : ", STDERR_FILENO);
-		ft_putendl_fd(strerror(errno), STDERR_FILENO);
-	}
+		ft_perror("dup");
 	else
 		data->stdfd[type] = newfd;
 	return (newfd);
@@ -39,8 +36,7 @@ int	ft_dup2(int oldfd, int newfd, int exit_status)
 		fd = dup2(oldfd, newfd);
 		if (fd == -1)
 		{
-			ft_putstr_fd("dup2 : ", STDERR_FILENO);
-			ft_putendl_fd(strerror(errno), STDERR_FILENO);
+			ft_perror("dup2");
 			if (exit_status)
 				exit(exit_status);
 		}
@@ -76,7 +72,7 @@ int	ft_open(t_iolist *filenode, int flags, mode_t mode)
 		fd = open(filenode->str, flags, mode);
 	if (fd == -1)
 	{
-		ft_putstr_fd("open: ", STDERR_FILENO);
+		ft_putstr_fd("minishell: ", STDERR_FILENO);
 		ft_putstr_fd(filenode->str, STDERR_FILENO);
 		ft_putstr_fd(": ", STDERR_FILENO);
 		perror("");

--- a/srcs/wrapper4.c
+++ b/srcs/wrapper4.c
@@ -5,3 +5,20 @@ void	ft_perror(char *perror_str)
 	ft_putstr_fd("minishell: ", STDERR_FILENO);
 	perror(perror_str);
 }
+
+void	ft_puterror(char *str1, char *str2, char *str3)
+{
+	ft_putstr_fd("minishell: ", STDERR_FILENO);
+	ft_putstr_fd(str1, STDERR_FILENO);
+	if (str2)
+	{
+		ft_putstr_fd(": ", STDERR_FILENO);
+		ft_putstr_fd(str2, STDERR_FILENO);
+	}
+	if (str3)
+	{
+		ft_putstr_fd(": ", STDERR_FILENO);
+		ft_putstr_fd(str3, STDERR_FILENO);
+	}
+	ft_putstr_fd("\n", STDERR_FILENO);
+}


### PR DESCRIPTION
### 初期化とメモリ解放
- new_iolst()でhered_doc_fd = -1の初期化が二箇所あったので一つ消したのですが大丈夫ですか？
- new_execdata()でstdfdの初期化も追加
- clear_iolist()でlist→here_doc_fdをclose処理追加(-1ならxclose内で無視されます)
- clear_ececdata()でcmdlineのfreeを追加
### その他の変更
- ワカモレでコンパイル対応できるようにMakefileを変更しました。
- setdata_cmdlien_redirection()でリダイレクション処理成功時の終了ステータス->0の作業を追加
- t_perrorとft_puterrorを作りエラー出力をまとめた