### PR TITLE
実行ファイル検索でエラーが起きた際の終了ステータス変更

### DIFF
--- a/srcs/command_nonbuiltin.c
+++ b/srcs/command_nonbuiltin.c
@@ -92,10 +92,10 @@ static char	*cmdpath_from_direct(char *cmd)
 	if (path_type == UNKNOWN)
 	{
 		ft_perror(cmd);
-		if (errno == 20)
-			g_status = 126;
-		else
+		if (errno == 2)
 			g_status = 127;
+		else
+			g_status = 126;
 	}
 	else if (path_type == EXECUTABLE)
 		cmd_path = cmd;

--- a/srcs/command_nonbuiltin.c
+++ b/srcs/command_nonbuiltin.c
@@ -92,7 +92,10 @@ static char	*cmdpath_from_direct(char *cmd)
 	if (path_type == UNKNOWN)
 	{
 		ft_perror(cmd);
-		g_status = 127;
+		if (errno == 20)
+			g_status = 126;
+		else
+			g_status = 127;
 	}
 	else if (path_type == EXECUTABLE)
 		cmd_path = cmd;


### PR DESCRIPTION
実行ファイル検索でstatがエラーを返した時、エラーの内容によって終了ステータスを変更するよう修正。(今までは無条件で127だった)
```
minishell$ /bin/no_such_file
minishell: /bin/no_such_file: No such file or directory
minishell$ echo $?
127
minishell$ /bin/ls/no_such_file
minishell: /bin/ls/no_such_file: Not a directory
minishell$ echo $?
126
```
no such file or directoryの時に127にして、それ以外は126にしました。
理由としてはパスの途中で権限が無かった際にもstatがエラーを出し、権限なしは終了ステータス126だからです。
今のところそこまで合わせられていればいいかなという見解ですが、どうですかね...?