### PR TITLE
close all open_fd at clear_list.c

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -2,7 +2,6 @@
 # define EXECUTE_H
 
 # include "minishell.h"
-# define FD_MAX 2000
 
 //execution_start.c
 int			execute_loop(t_execdata *data);
@@ -25,9 +24,8 @@ void		builtin_exit(t_execdata *data);
 void		non_builtin(t_execdata *data);
 
 //execution_utils.c
-
 void		execute_command(t_execdata *data);
-int			redirect_fd_handler(t_execdata *data, t_fd_mode mode, int fd);
+void		free_2d_array(char **array);
 
 //env_functions.c
 char		*ft_getenv(t_envlist *elst, char *search_key);
@@ -42,12 +40,11 @@ char		**convert_cmdlist_2dchar(t_cmdlist *clst);
 //execution_utils_libft.c
 long		ft_atol(char *str, bool *nonnum_check);
 int			ft_strcmp(char *s1, char *s2);
-void		free_2d_array(char **array);
 
 //wrapper2.c
 char		*ft_xstrjoin(char *str1, char *str2);
 char		**ft_xsplit(char *src_str, char cut_char);
-void		xclose(int fd);
+void		ft_close(int fd);
 pid_t		xfork(void);
 void		xwaitpid(pid_t pid, int *wstatus, int options);
 

--- a/includes/struct.h
+++ b/includes/struct.h
@@ -63,9 +63,6 @@ typedef enum e_fd_mode
 {
 	STD_SAVE,
 	STD_RESTORE,
-	FD_SPECIFIED,
-	FD_REDIRECTED,
-	ALL_CLOSE
 }	t_fd_mode;
 
 typedef struct s_token
@@ -82,7 +79,7 @@ typedef struct s_iolist
 	t_special_c		c_type;
 	char			*str;
 	char			*quot;
-	int				here_doc_fd;
+	int				open_fd;
 	struct s_iolist	*next;
 }	t_iolist;
 

--- a/srcs/clear_list.c
+++ b/srcs/clear_list.c
@@ -52,7 +52,7 @@ void	clear_iolist(t_iolist *list)
 	while (list)
 	{
 		next = list->next;
-		xclose(list->here_doc_fd);
+		ft_close(list->open_fd);
 		xfree(list->str);
 		xfree(list->quot);
 		xfree(list);

--- a/srcs/delimit_fd.c
+++ b/srcs/delimit_fd.c
@@ -8,7 +8,7 @@ static t_iolist	*insert_redirect_iolist(t_iolist *cur,
 	new = (t_iolist *)ft_xcalloc(1, sizeof(*new));
 	new->str = redirect;
 	new->quot = get_quot_flag(new->str);
-	new->here_doc_fd = -1;
+	new->open_fd = -1;
 	new->c_type = type;
 	cur->next = new;
 	return (new);

--- a/srcs/execdata.c
+++ b/srcs/execdata.c
@@ -55,9 +55,9 @@ static t_execdata	*new_execdata(t_execdata *cur, t_token *start,
 
 	new = (t_execdata *)ft_xcalloc(1, sizeof(*new));
 	new->cmdline = NULL;
-	new->stdfd[ORIGINAL_IN] = -1;
-	new->stdfd[ORIGINAL_OUT] = -1;
-	new->stdfd[ORIGINAL_ERR] = -1;
+	new->stdfd[ORIGINAL_IN] = -42;
+	new->stdfd[ORIGINAL_OUT] = -42;
+	new->stdfd[ORIGINAL_ERR] = -42;
 	new->clst = get_clst(start, cur_token);
 	new->iolst = get_iolst(start, cur_token);
 	new->elst = envlist;

--- a/srcs/execdata_utils.c
+++ b/srcs/execdata_utils.c
@@ -71,7 +71,7 @@ t_iolist	*new_iolst(t_iolist *cur, t_token *token)
 	t_iolist	*new;
 
 	new = (t_iolist *)ft_xcalloc(1, sizeof(*new));
-	new->here_doc_fd = -1;
+	new->open_fd = -1;
 	new->c_type = token->special;
 	cur->next = new;
 	new->str = ft_xstrdup(token->str);

--- a/srcs/execution_start.c
+++ b/srcs/execution_start.c
@@ -10,9 +10,11 @@ static void	child_execute(t_execdata *data, int prev_pipe_read, \
 						int piperead, int pipewrite)
 {
 	ft_dup2(prev_pipe_read, STDIN_FILENO, 1);
-	xclose(piperead);
+	ft_close(piperead);
 	if (data->next)
 		ft_dup2(pipewrite, STDOUT_FILENO, 1);
+	else
+		ft_close(pipewrite);
 	if (setdata_cmdline_redirect(data) != -1)
 		execute_command(data);
 	exit(g_status);
@@ -21,11 +23,11 @@ static void	child_execute(t_execdata *data, int prev_pipe_read, \
 static int	parent_connect_fd(t_execdata *data, int prev_pipe_read, \
 						int piperead, int pipewrite)
 {
-	xclose(pipewrite);
+	ft_close(pipewrite);
 	if (prev_pipe_read != STDIN_FILENO)
-		xclose(prev_pipe_read);
+		ft_close(prev_pipe_read);
 	if (data->next == NULL)
-		xclose(piperead);
+		ft_close(piperead);
 	return (piperead);
 }
 
@@ -82,7 +84,6 @@ static int	std_fd_handler(t_execdata *data, t_fd_mode mode)
 		ft_dup2(data->stdfd[ORIGINAL_IN], STDIN_FILENO, 1);
 		ft_dup2(data->stdfd[ORIGINAL_OUT], STDOUT_FILENO, 1);
 		ft_dup2(data->stdfd[ORIGINAL_ERR], STDERR_FILENO, 1);
-		redirect_fd_handler(data, ALL_CLOSE, 0);
 	}
 	return (ret);
 }

--- a/srcs/execution_utils.c
+++ b/srcs/execution_utils.c
@@ -18,31 +18,15 @@ void	execute_command(t_execdata *data)
 	cmd_func[data->cmd_type](data);
 }
 
-int	redirect_fd_handler(t_execdata *data, t_fd_mode mode, int fd)
+void	free_2d_array(char **array)
 {
-	static char	redfd_flag[FD_MAX + 1];
-	int			index_fd;
+	int	i;
 
-	if (mode == FD_SPECIFIED)
+	if (array)
 	{
-		if (data->stdfd[ORIGINAL_IN] == fd)
-			return (ft_dup(data, ORIGINAL_IN, fd));
-		else if (data->stdfd[ORIGINAL_OUT] == fd)
-			return (ft_dup(data, ORIGINAL_OUT, fd));
-		else if (data->stdfd[ORIGINAL_ERR] == fd)
-			return (ft_dup(data, ORIGINAL_ERR, fd));
+		i = -1;
+		while (array[++i])
+			free(array[i]);
+		free(array);
 	}
-	else if (mode == FD_REDIRECTED && \
-				!redfd_flag[fd] && STDERR_FILENO < fd)
-		redfd_flag[fd]++;
-	else if (mode == ALL_CLOSE)
-	{
-		index_fd = -1;
-		while (++index_fd <= FD_MAX)
-		{
-			if (redfd_flag[index_fd])
-				xclose(index_fd), redfd_flag[index_fd] = 0;
-		}
-	}
-	return (0);
 }

--- a/srcs/execution_utils_libft.c
+++ b/srcs/execution_utils_libft.c
@@ -61,16 +61,3 @@ int	ft_strcmp(char *s1, char *s2)
 		s2++;
 	}
 }
-
-void	free_2d_array(char **array)
-{
-	int	i;
-
-	if (array)
-	{
-		i = -1;
-		while (array[++i])
-			free(array[i]);
-		free(array);
-	}
-}

--- a/srcs/setdata_heredoc_cmdtype.c
+++ b/srcs/setdata_heredoc_cmdtype.c
@@ -63,7 +63,7 @@ static void	child_get_here_doc(char *limiter, t_execdata *data, \
 		}
 		free(line);
 	}
-	xclose(pipewrite);
+	ft_close(pipewrite);
 	exit(0);
 }
 
@@ -78,11 +78,11 @@ static int	get_here_doc(char *limiter, t_execdata *data, \
 	{
 		if (signal(SIGINT, child_handler) == SIG_ERR)
 			perror("signal"), exit(EXIT_FAILURE);
-		xclose(pipefd[READ]);
+		ft_close(pipefd[READ]);
 		child_get_here_doc(limiter, data, is_quot, pipefd[WRITE]);
 	}
-	xclose(pipefd[WRITE]);
-	iolst->here_doc_fd = pipefd[READ];
+	ft_close(pipefd[WRITE]);
+	iolst->open_fd = pipefd[READ];
 	wait(&wstatus);
 	g_status = WEXITSTATUS(wstatus);
 	if (g_status != 0)

--- a/srcs/wrapper2.c
+++ b/srcs/wrapper2.c
@@ -26,13 +26,10 @@ char	**ft_xsplit(char *src_str, char cut_char)
 	return (splited_str);
 }
 
-void	xclose(int fd)
+void	ft_close(int fd)
 {
-	if (0 <= fd && close(fd) == -1)
-	{
-		perror("close");
-		exit(EXIT_FAILURE);
-	}
+	if (0 <= fd)
+		close(fd);
 }
 
 pid_t	xfork(void)

--- a/srcs/wrapper3.c
+++ b/srcs/wrapper3.c
@@ -29,18 +29,21 @@ int	ft_dup2(int oldfd, int newfd, int exit_status)
 	int	fd;
 
 	fd = 0;
-	if (oldfd < 0 || newfd < 0)
+	if (oldfd < 0)
 		return (-1);
 	if (oldfd != newfd)
 	{
 		fd = dup2(oldfd, newfd);
 		if (fd == -1)
 		{
-			ft_perror("dup2");
+			if (errno == 9)
+				ft_perror("file descriptor out of range");
+			else
+				ft_perror("dup2");
 			if (exit_status)
 				exit(exit_status);
 		}
-		xclose(oldfd);
+		ft_close(oldfd);
 	}
 	return (fd);
 }


### PR DESCRIPTION
- here_doc_fdをopen_fdと名前変更
- redirect処理後にopen_fdにリダイレクトしたfdを代入しておいて、clear_list.c内で閉じます
- redirect_fd_handler()の処理が入らなくなったので、resave_stdfd()という名前に変えてsaveされているstdfdとの被りだけ見てます
- xcloseをft_closeにしました
