### PR TITLE
mod errno=

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -44,7 +44,7 @@ int			ft_strcmp(char *s1, char *s2);
 //wrapper2.c
 char		*ft_xstrjoin(char *str1, char *str2);
 char		**ft_xsplit(char *src_str, char cut_char);
-void		ft_close(int fd);
+void		xclose(int fd);
 pid_t		xfork(void);
 void		xwaitpid(pid_t pid, int *wstatus, int options);
 

--- a/srcs/clear_list.c
+++ b/srcs/clear_list.c
@@ -52,7 +52,7 @@ void	clear_iolist(t_iolist *list)
 	while (list)
 	{
 		next = list->next;
-		ft_close(list->open_fd);
+		xclose(list->open_fd);
 		xfree(list->str);
 		xfree(list->quot);
 		xfree(list);

--- a/srcs/command_builtin3.c
+++ b/srcs/command_builtin3.c
@@ -52,7 +52,7 @@ void	builtin_exit(t_execdata *data)
 	{
 		ft_puterror("exit", data->cmdline[1], \
 						"numeric argument required");
-		g_status = 255;
+		g_status = 2;
 	}
 	exit(g_status);
 }

--- a/srcs/command_nonbuiltin.c
+++ b/srcs/command_nonbuiltin.c
@@ -92,7 +92,7 @@ static char	*cmdpath_from_direct(char *cmd)
 	if (path_type == UNKNOWN)
 	{
 		ft_perror(cmd);
-		if (errno == 2)
+		if (errno == ENOENT)
 			g_status = 127;
 		else
 			g_status = 126;

--- a/srcs/execution_start.c
+++ b/srcs/execution_start.c
@@ -10,11 +10,11 @@ static void	child_execute(t_execdata *data, int prev_pipe_read, \
 						int piperead, int pipewrite)
 {
 	ft_dup2(prev_pipe_read, STDIN_FILENO, 1);
-	ft_close(piperead);
+	xclose(piperead);
 	if (data->next)
 		ft_dup2(pipewrite, STDOUT_FILENO, 1);
 	else
-		ft_close(pipewrite);
+		xclose(pipewrite);
 	if (setdata_cmdline_redirect(data) != -1)
 		execute_command(data);
 	exit(g_status);
@@ -23,11 +23,11 @@ static void	child_execute(t_execdata *data, int prev_pipe_read, \
 static int	parent_connect_fd(t_execdata *data, int prev_pipe_read, \
 						int piperead, int pipewrite)
 {
-	ft_close(pipewrite);
+	xclose(pipewrite);
 	if (prev_pipe_read != STDIN_FILENO)
-		ft_close(prev_pipe_read);
+		xclose(prev_pipe_read);
 	if (data->next == NULL)
-		ft_close(piperead);
+		xclose(piperead);
 	return (piperead);
 }
 

--- a/srcs/setdata_heredoc_cmdtype.c
+++ b/srcs/setdata_heredoc_cmdtype.c
@@ -63,7 +63,7 @@ static void	child_get_here_doc(char *limiter, t_execdata *data, \
 		}
 		free(line);
 	}
-	ft_close(pipewrite);
+	xclose(pipewrite);
 	exit(0);
 }
 
@@ -78,10 +78,10 @@ static int	get_here_doc(char *limiter, t_execdata *data, \
 	{
 		if (signal(SIGINT, child_handler) == SIG_ERR)
 			perror("signal"), exit(EXIT_FAILURE);
-		ft_close(pipefd[READ]);
+		xclose(pipefd[READ]);
 		child_get_here_doc(limiter, data, is_quot, pipefd[WRITE]);
 	}
-	ft_close(pipefd[WRITE]);
+	xclose(pipefd[WRITE]);
 	iolst->open_fd = pipefd[READ];
 	wait(&wstatus);
 	g_status = WEXITSTATUS(wstatus);

--- a/srcs/wrapper2.c
+++ b/srcs/wrapper2.c
@@ -26,10 +26,16 @@ char	**ft_xsplit(char *src_str, char cut_char)
 	return (splited_str);
 }
 
-void	ft_close(int fd)
+void	xclose(int fd)
 {
-	if (0 <= fd)
-		close(fd);
+	if (0 <= fd && close(fd) == -1)
+	{
+		if (errno != EBADF)
+		{
+			ft_perror("close");
+			exit(EXIT_FAILURE);
+		}
+	}
 }
 
 pid_t	xfork(void)

--- a/srcs/wrapper3.c
+++ b/srcs/wrapper3.c
@@ -36,14 +36,14 @@ int	ft_dup2(int oldfd, int newfd, int exit_status)
 		fd = dup2(oldfd, newfd);
 		if (fd == -1)
 		{
-			if (errno == 9)
+			if (errno == EBADF)
 				ft_perror("file descriptor out of range");
 			else
 				ft_perror("dup2");
 			if (exit_status)
 				exit(exit_status);
 		}
-		ft_close(oldfd);
+		xclose(oldfd);
 	}
 	return (fd);
 }


### PR DESCRIPTION
errnoの数値による条件分岐を定義されてるマクロに変更しました。

ft_closeをxcloseに戻し、errno == EBADF(fdが無効)な時はexitせず、それ以外のエラーはexitするようにしました。
fdが無効な時は開いているfdが放置されるわけではないので無視していいという考えです。
それ以外のエラーは対処の仕方がわからないのでexitさせるという考えです。

exitで引数がlongを超えたり数字出なかったりした場合に、manに従いexit status 2にしました。