### PR TITLE
mod ft_dup2()

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -52,7 +52,7 @@ void		xwaitpid(pid_t pid, int *wstatus, int options);
 int			ft_dup(t_execdata *data, t_stdfd type, int oldfd);
 int			ft_pipe(int *pipefd);
 t_path_type	ft_stat(char *pathname);
-int			ft_dup2(int oldfd, int newfd, int exit_status);
+int			ft_dup2(int oldfd, int newfd);
 int			ft_open(t_iolist *filenode, \
 					int flags, mode_t mode);
 

--- a/srcs/execution_start.c
+++ b/srcs/execution_start.c
@@ -9,10 +9,11 @@
 static void	child_execute(t_execdata *data, int prev_pipe_read, \
 						int piperead, int pipewrite)
 {
-	ft_dup2(prev_pipe_read, STDIN_FILENO, 1);
+	if (ft_dup2(prev_pipe_read, STDIN_FILENO) == -1)
+		exit(EXIT_FAILURE);
 	xclose(piperead);
-	if (data->next)
-		ft_dup2(pipewrite, STDOUT_FILENO, 1);
+	if (data->next && ft_dup2(pipewrite, STDOUT_FILENO) == -1)
+		exit(EXIT_FAILURE);
 	else
 		xclose(pipewrite);
 	if (setdata_cmdline_redirect(data) != -1)
@@ -81,9 +82,10 @@ static int	std_fd_handler(t_execdata *data, t_fd_mode mode)
 	}
 	else if (mode == STD_RESTORE)
 	{
-		ft_dup2(data->stdfd[ORIGINAL_IN], STDIN_FILENO, 1);
-		ft_dup2(data->stdfd[ORIGINAL_OUT], STDOUT_FILENO, 1);
-		ft_dup2(data->stdfd[ORIGINAL_ERR], STDERR_FILENO, 1);
+		if (ft_dup2(data->stdfd[ORIGINAL_IN], STDIN_FILENO) == -1 || \
+			ft_dup2(data->stdfd[ORIGINAL_OUT], STDOUT_FILENO) == -1 || \
+			ft_dup2(data->stdfd[ORIGINAL_ERR], STDERR_FILENO) == -1)
+			exit(EXIT_FAILURE);
 	}
 	return (ret);
 }

--- a/srcs/setdata_cmdline_redirection.c
+++ b/srcs/setdata_cmdline_redirection.c
@@ -45,19 +45,19 @@ static int	redirection(t_execdata *data, t_iolist *iolst, \
 	if (iolst->c_type != IN_HERE_DOC)
 		ret = expand_filename(iolst->next, data->elst);
 	if (ret != -1 && iolst->c_type == IN_REDIRECT)
-		ret = ft_dup2(ft_open(iolst->next, O_RDONLY, 0), redirect_fd, 0);
+		ret = ft_dup2(ft_open(iolst->next, O_RDONLY, 0), redirect_fd);
 	else if (ret != -1 && iolst->c_type == IN_HERE_DOC)
 	{
-		ret = ft_dup2(iolst->open_fd, redirect_fd, 0);
+		ret = ft_dup2(iolst->open_fd, redirect_fd);
 		iolst->open_fd = -1;
 	}
 	else if (ret != -1 && iolst->c_type == OUT_REDIRECT)
 		ret = ft_dup2(ft_open(iolst->next, O_WRONLY | O_CREAT | O_TRUNC, 0666), \
-						redirect_fd, 0);
+						redirect_fd);
 	else if (ret != -1 && iolst->c_type == OUT_HERE_DOC)
 		ret = ft_dup2(\
 				ft_open(iolst->next, O_WRONLY | O_CREAT | O_APPEND, 0666), \
-						redirect_fd, 0);
+						redirect_fd);
 	if (ret != -1 && STDERR_FILENO < redirect_fd)
 		iolst->open_fd = redirect_fd;
 	*is_fd_specified = 0;

--- a/srcs/wrapper3.c
+++ b/srcs/wrapper3.c
@@ -24,7 +24,7 @@ int	ft_dup(t_execdata *data, t_stdfd type, int oldfd)
 	return (newfd);
 }
 
-int	ft_dup2(int oldfd, int newfd, int exit_status)
+int	ft_dup2(int oldfd, int newfd)
 {
 	int	fd;
 
@@ -40,8 +40,6 @@ int	ft_dup2(int oldfd, int newfd, int exit_status)
 				ft_perror("file descriptor out of range");
 			else
 				ft_perror("dup2");
-			if (exit_status)
-				exit(exit_status);
 		}
 		xclose(oldfd);
 	}


### PR DESCRIPTION
ft_dup2()の引数にあった、エラー時exitをさせるフラグを無くして、単純に返り値を返すようにしました。
exitするかどうかは受け取り側で対処します。