### PR TITLE
mod $NON

### DIFF
--- a/includes/parse.h
+++ b/includes/parse.h
@@ -45,7 +45,7 @@ t_execdata	*check_syntax(t_execdata *data);
 void		put_syntax_error(char *str);
 
 // expansion
-void		serch_env_cmdlist(t_cmdlist *clist, t_envlist *envlist);
+void		serch_env_cmdlist(t_cmdlist **clist, t_envlist *envlist);
 char		*get_quot_flag(char *str);
 char		*get_removed_endflag(char **quot, char flag);
 size_t		ft_strlen_excluded_quot(char *str, char *quot);
@@ -58,6 +58,7 @@ size_t		get_space_idx(t_cmdlist *clist);
 bool		is_delimiter(char c);
 char		*ft_strjoin_three(char *str1, char *str2, char *str3);
 bool		is_delimiter_quot(char c, char flag);
+int			delone_cmdlist(t_cmdlist **cur, t_cmdlist *prev, t_cmdlist **head);
 
 // test
 void		put_execdata(t_execdata *data);

--- a/srcs/expansion_cmdlist.c
+++ b/srcs/expansion_cmdlist.c
@@ -102,24 +102,31 @@ static void	serch_new_space_cmdlist(t_cmdlist *clist)
 	}
 }
 
-void	serch_env_cmdlist(t_cmdlist *clist, t_envlist *envlist)
+void	serch_env_cmdlist(t_cmdlist **clist, t_envlist *envlist)
 {
-	char	*doll_ptr;
-	size_t	len;
+	char		*doll_ptr;
+	size_t		len;
+	t_cmdlist	*prev;
+	t_cmdlist	*head;
 
-	while (clist)
+	head = (*clist);
+	while ((*clist))
 	{
-		doll_ptr = ft_strdoll(clist->str);
-		while (doll_ptr != NULL && clist->quot[doll_ptr - clist->str] != 'S')
+		doll_ptr = ft_strdoll((*clist)->str);
+		while (doll_ptr && (*clist)->quot[doll_ptr - (*clist)->str] != 'S')
 		{
-			len = expansion_key_cmdlist(clist, envlist, doll_ptr);
-			free(clist->quot);
-			clist->quot = get_quot_flag(clist->str);
-			doll_ptr = ft_strdoll(clist->str + len);
+			len = expansion_key_cmdlist((*clist), envlist, doll_ptr);
+			free((*clist)->quot);
+			(*clist)->quot = get_quot_flag((*clist)->str);
+			doll_ptr = ft_strdoll((*clist)->str + len);
 		}
-		if (ft_strchr(clist->quot, '1') || ft_strchr(clist->quot, '2'))
-			clear_quot_cmdlist(clist);
-		serch_new_space_cmdlist(clist);
-		clist = clist->next;
+		if (!(*clist)->str[0] && delone_cmdlist(clist, prev, &head))
+			continue ;
+		if (ft_strchr((*clist)->quot, '1') || ft_strchr((*clist)->quot, '2'))
+			clear_quot_cmdlist((*clist));
+		serch_new_space_cmdlist((*clist));
+		prev = (*clist);
+		(*clist) = (*clist)->next;
 	}
+	(*clist) = (t_cmdlist *)head;
 }

--- a/srcs/expansion_utils1.c
+++ b/srcs/expansion_utils1.c
@@ -44,3 +44,24 @@ char	*get_removed_endflag(char **quot, char flag)
 	}
 	return (*quot);
 }
+
+int	delone_cmdlist(t_cmdlist **cur, t_cmdlist *prev, t_cmdlist **head)
+{
+	t_cmdlist	*tmp;
+
+	if (*cur == *head)
+	{
+		tmp = (*cur);
+		(*cur) = (*cur)->next;
+		free(tmp->str), free(tmp->quot), free(tmp);
+		(*head) = (*cur);
+	}
+	else
+	{
+		tmp = (*cur);
+		(*cur) = (*cur)->next;
+		prev->next = (*cur);
+		free(tmp->str), free(tmp->quot), free(tmp);
+	}
+	return (1);
+}

--- a/srcs/parse_cmd.c
+++ b/srcs/parse_cmd.c
@@ -7,7 +7,7 @@ static t_execdata	*expand_variable(t_execdata *data)
 	head = data;
 	while (data)
 	{
-		serch_env_cmdlist(data->clst, data->elst);
+		serch_env_cmdlist(&data->clst, data->elst);
 		data = data->next;
 	}
 	return (data);


### PR DESCRIPTION
close #104 
設定されていない環境変数を打たれたときに空のノードが生まれる問題を修正しました。

```sh
minishell$ $NO
minishell$ cat $NO
^C
minishell$ cat $NO aaa
cat: aaa: No such file or directory
```

## ソースコードの修正内容
- 変数展開後の文字列が空だったらそのノードを`delone_cmdlist()`で削除する。
- それがリストの先頭だった場合は`cmdlist`の先頭を変更する必要があるので`search_env_cmdlist()`の引数の`cmdlist`をダブルポインタにした。
