### PR TITLE
シグナルハンドラーを修正しました。

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -4,7 +4,6 @@
 # include "minishell.h"
 
 //execution_start.c
-int			execute_loop(t_execdata *data);
 void		execute_start(t_execdata *data);
 
 //setdata_cmdline_redirection.c
@@ -26,6 +25,7 @@ void		non_builtin(t_execdata *data);
 //execution_utils.c
 void		execute_command(t_execdata *data);
 void		free_2d_array(char **array);
+void		set_status_from_child_status(int wstatus);
 
 //env_functions.c
 char		*ft_getenv(t_envlist *elst, char *search_key);

--- a/srcs/execution_utils.c
+++ b/srcs/execution_utils.c
@@ -30,3 +30,14 @@ void	free_2d_array(char **array)
 		free(array);
 	}
 }
+
+void	set_status_from_child_status(int wstatus)
+{
+	if (WIFEXITED(wstatus))
+		g_status = WEXITSTATUS(wstatus);
+	else if (WIFSIGNALED(wstatus))
+	{
+		ft_putchar_fd('\n', STDOUT_FILENO);
+		g_status = WTERMSIG(wstatus) + 128;
+	}
+}

--- a/srcs/setdata_heredoc_cmdtype.c
+++ b/srcs/setdata_heredoc_cmdtype.c
@@ -74,17 +74,18 @@ static int	get_here_doc(char *limiter, t_execdata *data, \
 	int		wstatus;
 
 	ft_pipe(pipefd);
+	xsignal(SIGINT, SIG_IGN);
 	if (xfork() == 0)
 	{
-		if (signal(SIGINT, child_handler) == SIG_ERR)
-			perror("signal"), exit(EXIT_FAILURE);
+		xsignal(SIGINT, SIG_DFL);
 		xclose(pipefd[READ]);
 		child_get_here_doc(limiter, data, is_quot, pipefd[WRITE]);
 	}
 	xclose(pipefd[WRITE]);
 	iolst->open_fd = pipefd[READ];
 	wait(&wstatus);
-	g_status = WEXITSTATUS(wstatus);
+	xsignal(SIGINT, signal_handler);
+	set_status_from_child_status(wstatus);
 	if (g_status != 0)
 		return (-1);
 	return (0);

--- a/test/test_main.c
+++ b/test/test_main.c
@@ -1,8 +1,6 @@
 #include "minishell.h"
-#include "signal.h"
 
 unsigned char	g_status = 0;
-
 
 void end(void)__attribute__((destructor));
 void end(void)
@@ -14,16 +12,6 @@ void end(void)
     sprintf(cmd_str, "%s %d %s\n", "leaks", current_pid, ">> leaks.txt 2>&1");
     int ret = system(cmd_str);
     if (ret) printf("\e[31m!leak detected!\e[0m\n");
-}
-
-void	handler(int signo)
-{
-	(void)signo;
-	g_status = 128 + SIGINT;
-	ft_putchar_fd('\n', STDOUT_FILENO);
-	rl_replace_line("", 0);
-	rl_on_new_line();
-	rl_redisplay();
 }
 
 void	minishell_loop(char **envp)
@@ -56,12 +44,8 @@ void	minishell_loop(char **envp)
 
 int	main(int argc, char **argv, char **envp)
 {
-	if (signal(SIGINT, handler) == SIG_ERR
-		|| signal(SIGQUIT, SIG_IGN) == SIG_ERR)
-	{
-		perror("signal");
-		exit(EXIT_FAILURE);
-	}
+	xsignal(SIGINT, signal_handler);
+	xsignal(SIGQUIT, SIG_IGN);
 	minishell_loop(envp);
 	(void)argc;
 	(void)argv;


### PR DESCRIPTION
# get_here_doc()
- 子プロセス生成前にSIG_INT->IGN
- 子プロセスでSIG_INT->DFL
- 子プロセス終了後、親でSIG_INT->ハンドラー
# execute_loop()
- 子プロセス生成前にSIG_INT->IGN
- 子プロセスでSIG_INT->DFL,SIG_QUIT->DFL
- 子プロセス終了後、親でSIG_INT->ハンドラー
# その他
- 親プロセスで子プロセスの終了ステータスを拾う関数としてset_status_from_child_status()を追加