### PR TITLE
スペースだけの場合に対応しました

### DIFF
--- a/srcs/parse_tokenlist.c
+++ b/srcs/parse_tokenlist.c
@@ -53,9 +53,9 @@ static int	check_token_syntax(t_token *head, t_token *last)
 	int	ret;
 
 	ret = 0;
-	if (last->special == PIPE || head->special == PIPE)
+	if (last && (last->special == PIPE || head->special == PIPE))
 		put_syntax_error("|"), ret = -1;
-	if (last->special >= IN_REDIRECT && last->special <= OUT_HERE_DOC)
+	if (last && last->special >= IN_REDIRECT && last->special <= OUT_HERE_DOC)
 		put_syntax_error(last->str), ret = -1;
 	while (head && ret == 0)
 	{
@@ -82,6 +82,7 @@ int	parse_tokenlist(t_token *list)
 	char	*doll_ptr;
 
 	head = list;
+	prev = NULL;
 	while (list)
 	{
 		if (is_consecutive_redirect(list))

--- a/srcs/tokenize1.c
+++ b/srcs/tokenize1.c
@@ -54,11 +54,13 @@ t_quottype	get_flag_quot(char *cmd, t_quottype flag_quot)
 		return (DEFAULT);
 }
 
-static char	*skip_space(char **cmd)
+static int	init_vars(char **cmd, char **start, t_quottype *flag)
 {
-	while (ft_isspace(**cmd))
+	*flag = DEFAULT;
+	while (**cmd && ft_isspace(**cmd))
 		(*cmd)++;
-	return (*cmd);
+	*start = *cmd;
+	return (**start == '\0');
 }
 
 t_token	*tokenize_cmd_by_space(char *cmd, bool *err)
@@ -68,9 +70,9 @@ t_token	*tokenize_cmd_by_space(char *cmd, bool *err)
 	char		*start;
 	t_quottype	flag_quot;
 
-	flag_quot = DEFAULT;
 	cur = &head;
-	start = skip_space(&cmd);
+	if (init_vars(&cmd, &start, &flag_quot))
+		return (NULL);
 	while (*cmd)
 	{
 		if (ft_isspace(*cmd) && !(flag_quot == D_QUOT || flag_quot == S_QUOT))


### PR DESCRIPTION
close #106 

### srcs/tokenize1.c
`tokenize_cmd_by_space()`で、commandがスペースだけだった場合は
```
if (init_vars(&cmd, &start, &flag_quot))
		return (NULL);
```
でNULLを返すようにしました。


### srcs/parse_tokenlist.c
セグフォ対策を追加しました。