### PR TITLE
Ctrl+Dでexitするように変更しました。

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -14,7 +14,7 @@ void	minishell_loop(char **envp)
 		line = readline("minishell$ ");
 		if (!line)
 		{
-			ft_putstr_fd("\033[1A\033[11C", 1);
+			ft_putstr_fd("\033[1A\033[11C", STDOUT_FILENO);
 			line = ft_xstrdup("exit");
 		}
 		if (line[0] != '\0')

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -14,8 +14,8 @@ void	minishell_loop(char **envp)
 		line = readline("minishell$ ");
 		if (!line)
 		{
-			clear_envlist(elst);
-			break ;
+			ft_putstr_fd("\033[1A\033[11C", 1);
+			line = ft_xstrdup("exit");
 		}
 		if (line[0] != '\0')
 		{

--- a/test/test_main.c
+++ b/test/test_main.c
@@ -26,7 +26,7 @@ void	minishell_loop(char **envp)
 		line = readline("minishell$ ");
 		if (!line)
 		{
-			ft_putstr_fd("\033[1A\033[11C", 1);
+			ft_putstr_fd("\033[1A\033[11C", STDOUT_FILENO);
 			line = ft_xstrdup("exit");
 		}
 		if (line[0] != '\0')

--- a/test/test_main.c
+++ b/test/test_main.c
@@ -26,8 +26,8 @@ void	minishell_loop(char **envp)
 		line = readline("minishell$ ");
 		if (!line)
 		{
-			clear_envlist(elst);
-			break ;
+			ft_putstr_fd("\033[1A\033[11C", 1);
+			line = ft_xstrdup("exit");
 		}
 		if (line[0] != '\0')
 		{


### PR DESCRIPTION
動作例。Ctrl+Dを押されたら、前回の終了ステータスでexitします。
```
bash-3.2 ./minishell
minishell$ jklfjsd
minishell: jklfjsd: command not found
minishell$ exit
[127] bash-3.2 ./minishell
minishell$ exit
bash-3.2 ./minishell
minishell$ <jfkdslj
minishell: jfkdslj: No such file or directory
minishell$ exit
[1] bash-3.2
```