### PR TITLE
`< <` がシンタックスエラーになってない問題修正

### DIFF
--- a/srcs/parse_tokenlist.c
+++ b/srcs/parse_tokenlist.c
@@ -60,7 +60,10 @@ static int	check_token_syntax(t_token *head, t_token *last)
 	while (head && ret == 0)
 	{
 		if (head->special >= IN_REDIRECT && head->special <= OUT_HERE_DOC
-			&& ft_strlen(head->str) >= 3)
+			&& (ft_strlen(head->str) >= 3
+				|| (head->next
+				&& head->next->special >= IN_REDIRECT && head->next->special <= OUT_HERE_DOC))
+			)
 		{
 			ret = -1;
 			put_syntax_error(head->str);

--- a/srcs/parse_tokenlist.c
+++ b/srcs/parse_tokenlist.c
@@ -59,11 +59,8 @@ static int	check_token_syntax(t_token *head, t_token *last)
 		put_syntax_error(last->str), ret = -1;
 	while (head && ret == 0)
 	{
-		if (head->prev
-			&& head->prev->special >= IN_REDIRECT
-			&& head->prev->special <= OUT_HERE_DOC
-			&& head->special >= IN_REDIRECT
-			&& head->special <= OUT_HERE_DOC)
+		if (head->special >= IN_REDIRECT && head->special <= OUT_HERE_DOC
+			&& ft_strlen(head->str) >= 3)
 		{
 			ret = -1;
 			put_syntax_error(head->str);
@@ -85,8 +82,6 @@ int	parse_tokenlist(t_token *list)
 	prev = NULL;
 	while (list)
 	{
-		if (is_consecutive_redirect(list))
-			list = join_redirect(list);
 		doll_ptr = ft_strnstr(list->str, "$?", ft_strlen("list->str"));
 		if (doll_ptr && !is_in_squot(list->str, doll_ptr))
 		{

--- a/srcs/parse_tokenlist.c
+++ b/srcs/parse_tokenlist.c
@@ -62,8 +62,8 @@ static int	check_token_syntax(t_token *head, t_token *last)
 		if (head->special >= IN_REDIRECT && head->special <= OUT_HERE_DOC
 			&& (ft_strlen(head->str) >= 3
 				|| (head->next
-				&& head->next->special >= IN_REDIRECT && head->next->special <= OUT_HERE_DOC))
-			)
+					&& head->next->special >= IN_REDIRECT
+					&& head->next->special <= OUT_HERE_DOC)))
 		{
 			ret = -1;
 			put_syntax_error(head->str);

--- a/srcs/tokenize2.c
+++ b/srcs/tokenize2.c
@@ -39,11 +39,28 @@ static t_token	*get_newstr_list(t_token *list, char *delimiter_ptr)
 	return (list);
 }
 
+static bool	is_delimiter_to_split(char *ptr, char *head)
+{
+	if (*ptr == '|'
+		|| (ptr != head
+			&& ((*ptr != '<' && *ptr != '>'
+					&& (*(ptr - 1) == '<' || *(ptr - 1) == '>'))
+				|| (((*ptr == '<' && *(ptr - 1) != '<')
+						|| (*ptr == '>' && *(ptr - 1) != '>'))))))
+	{
+		return (true);
+	}
+	else
+	{
+		return (false);
+	}
+}
+
 /*
 ** @param(str): token list's str
 ** Return pointer to the character to be delimited.
 */
-char	*is_delimiter_operater(char *str)
+char	*get_delimiter_ptr(char *str)
 {
 	t_quottype	flag;
 	bool		nodigit;
@@ -54,10 +71,9 @@ char	*is_delimiter_operater(char *str)
 	flag = DEFAULT;
 	while (*str)
 	{
-		flag = get_flag_quot(str, flag);
 		if (head != str && !ft_isdigit(*(str - 1)))
 			nodigit = true;
-		if ((*str == '>' || *str == '<' || *str == '|')
+		if ((is_delimiter_to_split(str, head))
 			&& flag != D_QUOT && flag != S_QUOT
 			&& ((!nodigit && *(str + 1) != '\0') || nodigit))
 		{
@@ -65,6 +81,7 @@ char	*is_delimiter_operater(char *str)
 				str++;
 			return (str);
 		}
+		flag = get_flag_quot(str, flag);
 		str++;
 	}
 	return (NULL);
@@ -78,7 +95,7 @@ int	split_operater(t_token *list)
 	head = list;
 	while (list)
 	{
-		delimiter_ptr = is_delimiter_operater(list->str);
+		delimiter_ptr = get_delimiter_ptr(list->str);
 		if (ft_strlen(list->str) >= 2 && delimiter_ptr)
 		{
 			list = get_newstr_list(list, delimiter_ptr);

--- a/srcs/tokenize_utils.c
+++ b/srcs/tokenize_utils.c
@@ -1,43 +1,5 @@
 #include "minishell.h"
 
-t_token	*join_redirect(t_token *list)
-{
-	t_token	*next;
-
-	next = NULL;
-	if (list->next)
-		next = list->next->next;
-	if (list->next->str[0] == '>')
-	{
-		free(list->str);
-		list->str = ft_xstrdup(">>");
-	}
-	if (list->next->str[0] == '<')
-	{
-		free(list->str);
-		list->str = ft_xstrdup("<<");
-	}
-	if (list->next)
-	{
-		free(list->next->str);
-		free(list->next);
-		list->next = next;
-	}
-	if (next)
-		next->prev = list;
-	return (list);
-}
-
-bool	is_consecutive_redirect(t_token *list)
-{
-	if (list->next
-		&& ((list->str[0] == '>' && list->next->str[0] == '>')
-			|| (list->str[0] == '<' && list->next->str[0] == '<')))
-		return (true);
-	else
-		return (false);
-}
-
 void	set_special_c(t_token *list)
 {
 	while (list)


### PR DESCRIPTION
```
> >a
```
と
```
>>a
```
の区別ができていませんでした。

test.shも通ってるのを確認しました。
```
minishell$ ls > >a
minishell: syntax error near unexpected token >
minishell$ ls > > a
minishell: syntax error near unexpected token >
minishell$ ls < < a
minishell: syntax error near unexpected token <
```

`static bool	is_delimiter_to_split(char *ptr, char *head)`のif文、吐きそうですね
