### PR TITLE
support `1>>a`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,4 +85,7 @@ test:
 test_fclean:
 	${MAKE} fclean TEST_MODE=1
 
+check:
+	cd ./test && ./test.sh
+
 .PHONY: all clean fclean re val test test_fclean

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -27,6 +27,7 @@ t_quottype	get_flag_quot(char *cmd, t_quottype flag_quot);
 // parse tokenlist
 int			parse_tokenlist(t_token *list);
 void		set_special_c(t_token *list);
+void		put_syntax_error(char *str);
 
 // execdata
 t_execdata	*create_execdata(t_token *tokenlist,

--- a/srcs/execdata.c
+++ b/srcs/execdata.c
@@ -19,7 +19,7 @@ static t_iolist	*get_iolst(t_token *start, t_token *cur_token)
 		if (!is_cmd(start))
 		{
 			cur = new_iolst(cur, start);
-			if (cur->c_type >= IN_REDIRECT && cur->c_type <= OUT_REDIRECT
+			if (cur->c_type >= IN_REDIRECT && cur->c_type <= OUT_HERE_DOC
 				&& ft_isdigit(cur->str[0]))
 			{
 				cur = delimit_fd(cur);

--- a/srcs/parse_tokenlist.c
+++ b/srcs/parse_tokenlist.c
@@ -7,13 +7,6 @@
 ** 3 Check syntax error.
 */
 
-void	put_syntax_error(char *str)
-{
-	ft_putstr_fd("minishell: syntax error near unexpected token ",
-		 STDERR_FILENO);
-	ft_putendl_fd(str, STDERR_FILENO);
-}
-
 static void	expand_status(t_token *list, char *doll_ptr)
 {
 	char	*front;
@@ -48,6 +41,16 @@ static bool	is_in_squot(char *str, char *doll_ptr)
 	return (false);
 }
 
+static bool	is_syntax_error(t_token *list)
+{
+	return ((list->special >= IN_REDIRECT && list->special <= OUT_HERE_DOC
+			&& list->next
+			&& list->next->special >= IN_REDIRECT
+			&& list->next->special <= OUT_HERE_DOC)
+		|| (ft_strnstr(list->str, ">>>", ft_strlen(list->str))
+			||ft_strnstr(list->str, "<<<", ft_strlen(list->str))));
+}
+
 static int	check_token_syntax(t_token *head, t_token *last)
 {
 	int	ret;
@@ -59,11 +62,7 @@ static int	check_token_syntax(t_token *head, t_token *last)
 		put_syntax_error(last->str), ret = -1;
 	while (head && ret == 0)
 	{
-		if (head->special >= IN_REDIRECT && head->special <= OUT_HERE_DOC
-			&& (ft_strlen(head->str) >= 3
-				|| (head->next
-					&& head->next->special >= IN_REDIRECT
-					&& head->next->special <= OUT_HERE_DOC)))
+		if (is_syntax_error(head))
 		{
 			ret = -1;
 			put_syntax_error(head->str);

--- a/srcs/tokenize2.c
+++ b/srcs/tokenize2.c
@@ -39,21 +39,18 @@ static t_token	*get_newstr_list(t_token *list, char *delimiter_ptr)
 	return (list);
 }
 
-static bool	is_delimiter_to_split(char *ptr, char *head)
+static bool	is_delimiter_to_split(char *ptr, char *head, bool nodigit)
 {
 	if (*ptr == '|'
 		|| (ptr != head
 			&& ((*ptr != '<' && *ptr != '>'
 					&& (*(ptr - 1) == '<' || *(ptr - 1) == '>'))
-				|| (((*ptr == '<' && *(ptr - 1) != '<')
+				|| (nodigit && ((*ptr == '<' && *(ptr - 1) != '<')
 						|| (*ptr == '>' && *(ptr - 1) != '>'))))))
 	{
 		return (true);
 	}
-	else
-	{
-		return (false);
-	}
+	return (false);
 }
 
 /*
@@ -73,7 +70,7 @@ char	*get_delimiter_ptr(char *str)
 	{
 		if (head != str && !ft_isdigit(*(str - 1)))
 			nodigit = true;
-		if ((is_delimiter_to_split(str, head))
+		if (is_delimiter_to_split(str, head, nodigit)
 			&& flag != D_QUOT && flag != S_QUOT
 			&& ((!nodigit && *(str + 1) != '\0') || nodigit))
 		{

--- a/srcs/tokenize_utils.c
+++ b/srcs/tokenize_utils.c
@@ -21,3 +21,10 @@ void	set_special_c(t_token *list)
 		list = list->next;
 	}
 }
+
+void	put_syntax_error(char *str)
+{
+	ft_putstr_fd("minishell: syntax error near unexpected token ",
+		 STDERR_FILENO);
+	ft_putendl_fd(str, STDERR_FILENO);
+}


### PR DESCRIPTION
- srcs/execdata.cの22行目でfdとリダイレクトを区切っているのですが、<< と >>でも区切れるようにしました。
- `1>>`と`>>>`をシンタックスチェックで区別しないといけないのでis_syntax_error()を作りました。