### PR TITLE
in:echo printf()->ft_putstr_fd()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,10 @@ val:
 test:
 	${MAKE} TEST_MODE=1
 
-test_fclean:
+tclean:
 	${MAKE} fclean TEST_MODE=1
 
 check:
 	cd ./test && ./test.sh
 
-.PHONY: all clean fclean re val test test_fclean
+.PHONY: all clean fclean re val test tclean

--- a/srcs/command_builtin1.c
+++ b/srcs/command_builtin1.c
@@ -26,13 +26,13 @@ void	builtin_echo(t_execdata *data)
 		option++;
 	while (data->cmdline[arg_i])
 	{
-		printf("%s", data->cmdline[arg_i]);
+		ft_putstr_fd(data->cmdline[arg_i], STDOUT_FILENO);
 		if (data->cmdline[arg_i + 1] != NULL)
-			printf(" ");
+			ft_putstr_fd(" ", STDOUT_FILENO);
 		arg_i++;
 	}
 	if (option == 0)
-		printf("\n");
+		ft_putstr_fd("\n", STDOUT_FILENO);
 	g_status = 0;
 }
 


### PR DESCRIPTION
下記で、fileに出力されずに標準出力に出力されてしまったので修正しました。
```
echo -n aaa >file
```
nオプションの際、改行コードが出力されないため"aaa"がバッファリングされたまま次の動作に入ってしまい、リダイレクト先に出力されない現象が起きたため、
printf()->ft_putstr_fd()に変更しました。