### PR TITLE
envlist関連を変更しました。

### DIFF
--- a/includes/execute.h
+++ b/includes/execute.h
@@ -30,7 +30,7 @@ void		set_status_from_child_status(int wstatus);
 //env_functions.c
 char		*ft_getenv(t_envlist *elst, char *search_key);
 t_envlist	*ft_unsetenv(t_envlist *elst, char *rm_key);
-void		ft_setenv(t_envlist *elst, char *new_key, \
+t_envlist	*ft_setenv(t_envlist *head, char *new_key, \
 						char *new_value, int append);
 
 //execution_utils_list.c

--- a/srcs/command_builtin1.c
+++ b/srcs/command_builtin1.c
@@ -50,9 +50,10 @@ void	builtin_cd(t_execdata *data)
 		free(old_pwd);
 		return ;
 	}
-	ft_setenv(data->elst, ft_xstrdup("OLDPWD"), old_pwd, 0);
+	data->elst = ft_setenv(data->elst, ft_xstrdup("OLDPWD"), old_pwd, 0);
 	if (ft_getenv(data->elst, "PWD"))
-		ft_setenv(data->elst, ft_xstrdup("PWD"), getcwd(NULL, 0), 0);
+		data->elst = \
+			ft_setenv(data->elst, ft_xstrdup("PWD"), getcwd(NULL, 0), 0);
 	g_status = 0;
 }
 

--- a/srcs/command_builtin2.c
+++ b/srcs/command_builtin2.c
@@ -25,7 +25,7 @@ static ssize_t	check_name_rule(char *src_str)
 	return (i);
 }
 
-static void	to_setenv(t_envlist *head, char *src_str, size_t i)
+static t_envlist	*to_setenv(t_envlist *head, char *src_str, size_t i)
 {
 	char	*key;
 	char	*value;
@@ -49,7 +49,7 @@ static void	to_setenv(t_envlist *head, char *src_str, size_t i)
 		value = NULL;
 		mode = 0;
 	}
-	ft_setenv(head, key, value, mode);
+	return (ft_setenv(head, key, value, mode));
 }
 
 static void	put_env_asciiorder(t_envlist *head, t_envlist *min_node)
@@ -95,7 +95,8 @@ void	builtin_export(t_execdata *data)
 		{
 			split_point = check_name_rule(data->cmdline[arg_i]);
 			if (split_point != -1)
-				to_setenv(data->elst, data->cmdline[arg_i], split_point);
+				data->elst = \
+					to_setenv(data->elst, data->cmdline[arg_i], split_point);
 			else
 			{
 				ft_puterror("export", data->cmdline[arg_i], \

--- a/srcs/command_builtin3.c
+++ b/srcs/command_builtin3.c
@@ -14,7 +14,7 @@ void	builtin_unset(t_execdata *data)
 	i = 1;
 	while (data->cmdline[i])
 	{
-		ft_unsetenv(data->elst, data->cmdline[i]);
+		data->elst = ft_unsetenv(data->elst, data->cmdline[i]);
 		i++;
 	}
 	g_status = 0;

--- a/srcs/env_functions.c
+++ b/srcs/env_functions.c
@@ -41,21 +41,31 @@ t_envlist	*ft_unsetenv(t_envlist *elst, char *rm_key)
 	return (head);
 }
 
-static t_envlist	*get_elst_node(char *new_key, char *new_value)
+static t_envlist	*get_elst_node(t_envlist *head, t_envlist *prev, \
+										char *new_key, char *new_value)
 {
 	t_envlist	*new_elst;
 
 	new_elst = ft_xcalloc(1, sizeof(*new_elst));
 	new_elst->key = new_key;
 	new_elst->value = new_value;
-	return (new_elst);
+	new_elst->next = NULL;
+	if (head == NULL)
+		return (new_elst);
+	prev->next = new_elst;
+	return (head);
 }
 
-void	ft_setenv(t_envlist *elst, char *new_key, char *new_value, int append)
+t_envlist	*ft_setenv(t_envlist *elst, char *new_key, \
+									char *new_value, int append)
 {
 	char		*add_value;
+	t_envlist	*head;
+	t_envlist	*prev;
 
-	while (1)
+	head = elst;
+	prev = NULL;
+	while (elst)
 	{
 		if (ft_strcmp(elst->key, new_key) == 0)
 		{
@@ -65,16 +75,13 @@ void	ft_setenv(t_envlist *elst, char *new_key, char *new_value, int append)
 					add_value = ft_xstrjoin(elst->value, new_value);
 				else
 					add_value = ft_xstrdup(new_value);
-				free(new_value);
-				free(elst->value);
-				elst->value = add_value;
+				free(new_value), free(elst->value), elst->value = add_value;
 			}
 			free(new_key);
-			return ;
+			return (head);
 		}
-		if (elst->next == NULL)
-			break ;
+		prev = elst;
 		elst = elst->next;
 	}
-	elst->next = get_elst_node(new_key, new_value);
+	return (get_elst_node(head, prev, new_key, new_value));
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -18,6 +18,7 @@ void	minishell_loop(char **envp)
 		{
 			data = parse_cmd(line, elst);
 			execute_start(data);
+			elst = data->elst;
 			clear_execdata(data);
 			add_history(line);
 		}

--- a/test/files_for_test/test_main.c
+++ b/test/files_for_test/test_main.c
@@ -33,12 +33,13 @@ void	minishell_loop(char **envp)
 		{
 			data = parse_cmd(line, elst);
 			execute_start(data);
+			elst = data->elst;
 			clear_execdata(data);
 			add_history(line);
 		}
+		free(line);
 		if (g_status != 0)
 			printf("\x1b[31m[%d] \033[m", g_status);
-		free(line);
 	}
 }
 


### PR DESCRIPTION
# 目的
以下で、data->elstを変更してもmain()のelstには反映されずenvlistの更新ができなかったので、
main()のwhile内でelstをdata->elstで更新するようにしました。
- unset、envlistの先頭ノードを消す
- export、envlistがNULLの時(env -i)、新しくノードを作成してもmain()のelstはNULLのまま
# 変更点
- main()、elstをdata->elstで更新
- ft_setenv()、listの先頭アドレスを返すようにしてlistがNULLでも、返り値で新ノードを追加できるようにした
- その他、ft_setenv()/ft_unsetenv()の呼び出し元ではdata->elstに返り値を受け取るようにした
->istのどこが変更されても更新できるように