### PR TITLE
環境変数のあとのスペースが消されるやつ修正

### DIFF
--- a/includes/parse.h
+++ b/includes/parse.h
@@ -47,6 +47,7 @@ char		*get_quot_flag(char *str);
 char		*get_removed_endflag(char **quot, char flag);
 size_t		ft_strlen_excluded_quot(char *str, char *quot);
 size_t		get_space_idx(t_cmdlist *clist);
+char		*ft_strdoll_cmdlist(const char *s, t_cmdlist *clist);
 
 // expansion_utils
 bool		is_delimiter(char c);

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -47,7 +47,7 @@ char		*get_quot_flag(char *str);
 char		*get_removed_endflag(char **quot, char flag);
 size_t		ft_strlen_excluded_quot(char *str, char *quot);
 size_t		get_space_idx(t_cmdlist *clist);
-char		*ft_strdoll_cmdlist(const char *s, t_cmdlist *clist);
+char		*ft_strdoll_cmdlist(char *s, char *clist, char *head);
 
 // expansion_utils
 bool		is_delimiter(char c);

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -47,7 +47,7 @@ char		*get_quot_flag(char *str);
 char		*get_removed_endflag(char **quot, char flag);
 size_t		ft_strlen_excluded_quot(char *str, char *quot);
 size_t		get_space_idx(t_cmdlist *clist);
-char		*ft_strdoll_cmdlist(char *s, char *clist, char *head);
+char		*ft_strdol(char *s, char *clist, char *head);
 
 // expansion_utils
 bool		is_delimiter(char c);

--- a/srcs/expansion_cmdlist.c
+++ b/srcs/expansion_cmdlist.c
@@ -116,13 +116,13 @@ void	expand_cmdlist(t_cmdlist **clist, t_envlist *envlist)
 	head = (*clist);
 	while ((*clist))
 	{
-		doll_ptr = ft_strdoll_cmdlist((*clist)->str, *clist);
-		while (doll_ptr && (*clist)->quot[doll_ptr - (*clist)->str] != 'S')
+		doll_ptr = ft_strdoll_cmdlist((*clist)->str, (*clist)->quot, (*clist)->str);
+		while (doll_ptr)
 		{
 			len = expand_key_cmdlist((*clist), envlist, doll_ptr);
 			free((*clist)->quot);
 			(*clist)->quot = get_quot_flag((*clist)->str);
-			doll_ptr = ft_strdoll_cmdlist((*clist)->str + len, *clist);
+			doll_ptr = ft_strdoll_cmdlist((*clist)->str + len, (*clist)->quot, (*clist)->str);
 		}
 		if (!(*clist)->str[0] && delone_cmdlist(clist, prev, &head))
 			continue ;

--- a/srcs/expansion_cmdlist.c
+++ b/srcs/expansion_cmdlist.c
@@ -116,20 +116,20 @@ void	expand_cmdlist(t_cmdlist **clist, t_envlist *envlist)
 	head = (*clist);
 	while ((*clist))
 	{
-		doll_ptr = ft_strdoll_cmdlist((*clist)->str, (*clist)->quot, (*clist)->str);
+		doll_ptr = ft_strdol((*clist)->str, (*clist)->quot, (*clist)->str);
 		while (doll_ptr)
 		{
 			len = expand_key_cmdlist((*clist), envlist, doll_ptr);
 			free((*clist)->quot);
 			(*clist)->quot = get_quot_flag((*clist)->str);
-			doll_ptr = ft_strdoll_cmdlist((*clist)->str + len, (*clist)->quot, (*clist)->str);
+			doll_ptr = ft_strdol((*clist)->str + len,
+					(*clist)->quot, (*clist)->str);
 		}
 		if (!(*clist)->str[0] && delone_cmdlist(clist, prev, &head))
 			continue ;
 		if (ft_strchr((*clist)->quot, '1') || ft_strchr((*clist)->quot, '2'))
 			clear_quot_cmdlist((*clist));
-		search_new_space_cmdlist((*clist));
-		prev = (*clist);
+		search_new_space_cmdlist((*clist)), prev = (*clist);
 		(*clist) = (*clist)->next;
 	}
 	(*clist) = head;

--- a/srcs/expansion_utils1.c
+++ b/srcs/expansion_utils1.c
@@ -56,7 +56,7 @@ int	delone_cmdlist(t_cmdlist **cur, t_cmdlist *prev, t_cmdlist **head)
 	return (1);
 }
 
-char	*ft_strdoll_cmdlist(char *s, char *quot, char *head)
+char	*ft_strdol(char *s, char *quot, char *head)
 {
 	char	*doll_ptr;
 
@@ -64,7 +64,7 @@ char	*ft_strdoll_cmdlist(char *s, char *quot, char *head)
 	if (doll_ptr
 		&& (is_delimiter(*(doll_ptr + 1))
 			|| quot[doll_ptr - head] == 'S'))
-		return (ft_strdoll_cmdlist(doll_ptr + 1, quot, head));
+		return (ft_strdol(doll_ptr + 1, quot, head));
 	else
 		return (doll_ptr);
 }

--- a/srcs/expansion_utils1.c
+++ b/srcs/expansion_utils1.c
@@ -55,3 +55,16 @@ int	delone_cmdlist(t_cmdlist **cur, t_cmdlist *prev, t_cmdlist **head)
 	}
 	return (1);
 }
+
+char	*ft_strdoll_cmdlist(const char *s, t_cmdlist *clist)
+{
+	char	*doll_ptr;
+
+	doll_ptr = ft_strchr(s, '$');
+	if (doll_ptr
+		&& (is_delimiter(*(doll_ptr + 1))
+			|| clist->quot[doll_ptr - clist->str] == 'S'))
+		return (ft_strdoll(doll_ptr + 1));
+	else
+		return (doll_ptr);
+}

--- a/srcs/expansion_utils1.c
+++ b/srcs/expansion_utils1.c
@@ -56,15 +56,15 @@ int	delone_cmdlist(t_cmdlist **cur, t_cmdlist *prev, t_cmdlist **head)
 	return (1);
 }
 
-char	*ft_strdoll_cmdlist(const char *s, t_cmdlist *clist)
+char	*ft_strdoll_cmdlist(char *s, char *quot, char *head)
 {
 	char	*doll_ptr;
 
 	doll_ptr = ft_strchr(s, '$');
 	if (doll_ptr
 		&& (is_delimiter(*(doll_ptr + 1))
-			|| clist->quot[doll_ptr - clist->str] == 'S'))
-		return (ft_strdoll(doll_ptr + 1));
+			|| quot[doll_ptr - head] == 'S'))
+		return (ft_strdoll_cmdlist(doll_ptr + 1, quot, head));
 	else
 		return (doll_ptr);
 }

--- a/test/cmdline.txt
+++ b/test/cmdline.txt
@@ -12,7 +12,7 @@ echo " " " """ | ''c'at' -e
 echo ">"
 echo ">>"
 echo $SPACE2"cc     "
-echo $SPACE2"    cc     "
+echo $SPACE2"    cc     "$SPACE2
 echo $
 echo $ |	cat
 echo $?

--- a/test/cmdline.txt
+++ b/test/cmdline.txt
@@ -1,3 +1,4 @@
+echo a\npwd
 echo aaa|cat
    echo aaa|cat
 echo aaa|cat	\
@@ -10,7 +11,8 @@ echo '' '' | cat -e
 echo " " " """ | ''c'at' -e
 echo ">"
 echo ">>"
-eCHo aaa
+echo $SPACE2"cc     "
+echo $SPACE2"    cc     "
 echo $
 echo $ |	cat
 echo $?

--- a/test/error_cmdline.txt
+++ b/test/error_cmdline.txt
@@ -70,6 +70,8 @@ exit 42 42
 
 exit a
 
+exit a a a
+
 exit 1a
 
 exit +


### PR DESCRIPTION
`static size_t	search_new_space_cmdlist(t_cmdlist *clist, size_t idx)`を主に変更してます。
変数展開後のインデックス(expand_key_cmdlist()の返り値)を使って、どこまでが環境変数だったか判別できるようにしました。スペースで区切ってノードを追加していく処理の中で文字列のインデックスが環境変数だった場所を超えたらidxをSIZE_MAXにして処理を終了してます。


```
if (idx > i)
			idx -= i;
		else
			idx = SIZE_MAX;
```

`test/cmdline.txt`の14~15行目でテストしてます。
分かりづらいと思うので一旦放置でも大丈夫です。