### PR TITLE
mod exit

### DIFF
--- a/srcs/command_builtin3.c
+++ b/srcs/command_builtin3.c
@@ -39,20 +39,21 @@ void	builtin_exit(t_execdata *data)
 	bool	nonnum_check;
 
 	ft_putendl_fd("exit", STDERR_FILENO);
-	if (data->cmdline[1] == NULL)
-		exit(g_status);
-	if (data->cmdline[2])
+	if (data->cmdline[1])
 	{
-		ft_puterror("exit", "too many arguments", NULL);
-		g_status = 2;
-		return ;
-	}
-	g_status = (unsigned char)ft_atol(data->cmdline[1], &nonnum_check);
-	if (nonnum_check)
-	{
-		ft_puterror("exit", data->cmdline[1], \
-						"numeric argument required");
-		g_status = 2;
+		g_status = (unsigned char)ft_atol(data->cmdline[1], &nonnum_check);
+		if (nonnum_check)
+		{
+			ft_puterror("exit", data->cmdline[1], \
+							"numeric argument required");
+			g_status = 2;
+		}
+		else if (data->cmdline[2])
+		{
+			ft_puterror("exit", "too many arguments", NULL);
+			g_status = 1;
+			return ;
+		}
 	}
 	exit(g_status);
 }


### PR DESCRIPTION
以下に対応するよう、exitを修正しました。
- exit abc abc
第一引数が数字ではないのでエラー文吐くがexitはする、status=2
- exit abc 42
上記と同じく
- exit 42 abc
引数が複数なのでエラー、exitしない、status=1
- exit 42 42
上記と同じく